### PR TITLE
Reorganize team routes for clarity and maintainability

### DIFF
--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -15,23 +15,18 @@ const { authenticateToken, optionalAuth } = require('../middlewares/auth');
 // Create team: optional JWT — guests create without auth; logged-in users must send Bearer so req.user is set
 router.post('/', optionalAuth, createTeam);
 
+// Static paths MUST be registered before `/:id` or Express will treat e.g. "verify-invitation" as a team id.
+router.get('/verify-invitation', verifyInvitation);
+router.post('/accept-invitation-new-user', acceptInvitationNewUser);
+router.post('/accept-invitation', authenticateToken, acceptInvitation);
+router.post('/invitations/:token/accept', authenticateToken, acceptInvitation);
+router.post('/invitations/:token/decline', authenticateToken, declineInvitation);
+router.post('/decline-invitation', authenticateToken, declineInvitation);
+
 // Get team by ID (authenticated — team members or admin/board)
 router.get('/:id', authenticateToken, getTeamById);
 
 // Send invitation (authenticated, leader only)
 router.post('/:id/invite', authenticateToken, inviteToTeam);
-
-// Verify invitation token (public - no auth required)
-router.get('/verify-invitation', verifyInvitation);
-
-// Accept invitation for new user - creates account with password (public - no auth required)
-router.post('/accept-invitation-new-user', acceptInvitationNewUser);
-
-// Accept invitation for existing user (authenticated)
-router.post('/accept-invitation', authenticateToken, acceptInvitation);
-router.post('/invitations/:token/accept', authenticateToken, acceptInvitation);
-// Decline invitation (authenticated)
-router.post('/invitations/:token/decline', authenticateToken, declineInvitation);
-router.post('/decline-invitation', authenticateToken, declineInvitation);
 
 module.exports = router;


### PR DESCRIPTION
- Moved static paths to be registered before dynamic routes to prevent misinterpretation by Express.
- Rearranged the order of team-related routes for better readability and logical flow.
- Ensured that invitation-related routes remain accessible while maintaining authentication requirements.

📝 PR Details (Optional):