### PR TITLE
Update package-lock.json to include bcrypt and node-gyp-build dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8266,6 +8266,17 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.23",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
@@ -11347,6 +11358,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.940.0",
         "adm-zip": "^0.5.16",
+        "bcrypt": "^6.0.0",
         "chrome-launcher": "^1.1.2",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -11362,6 +11374,29 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
+      }
+    },
+    "server/node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "server/node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     }
   }


### PR DESCRIPTION
- Added bcrypt version 6.0.0 for password hashing functionality.
- Included node-gyp-build version 4.8.4 as a dependency for bcrypt.
- Updated node-addon-api to version 8.7.0 to support bcrypt's requirements.