### PR TITLE
Update team invitation query to use invited_at for sorting

### DIFF
--- a/server/controllers/admin.js
+++ b/server/controllers/admin.js
@@ -756,10 +756,10 @@ const getAdminTeamDetails = async (req, res) => {
                     ti.invited_university_id,
                     ti.status,
                     ti.expires_at,
-                    ti.created_at
+                    ti.invited_at AS created_at
              FROM team_invitations ti
              WHERE ti.team_id = ? AND ti.status = 'pending'
-             ORDER BY ti.created_at ASC`,
+             ORDER BY ti.invited_at ASC`,
             {
                 replacements: [id],
                 type: QueryTypes.SELECT


### PR DESCRIPTION
- Modified the SQL query in getAdminTeamDetails to sort pending team invitations by invited_at instead of created_at, ensuring accurate ordering of invitations based on their invitation date.