### PR TITLE
Add task quiz marks functionality and UI updates

### DIFF
--- a/client/src/pages/CompetitionDetails.jsx
+++ b/client/src/pages/CompetitionDetails.jsx
@@ -30,6 +30,7 @@ const CompetitionDetails = () => {
   const [userRole, setUserRole] = useState(null);
   const [userId, setUserId] = useState(null);
   const [userTeam, setUserTeam] = useState(null);
+  const [taskQuizMarksGate, setTaskQuizMarksGate] = useState(null);
 
   // Check user role and fetch competition
   useEffect(() => {
@@ -63,11 +64,21 @@ const CompetitionDetails = () => {
           try {
             const team = await ApiService.getUserTeamForCompetition(id);
             setUserTeam(team);
+            if (compData?.type === 'task_quiz' && team?.team_id) {
+              const marksData = await ApiService
+                .getMyTaskQuizEvaluation(id, team.team_id)
+                .catch(() => null);
+              setTaskQuizMarksGate(marksData?.readiness || null);
+            } else {
+              setTaskQuizMarksGate(null);
+            }
           } catch (err) {
             setUserTeam(null);
+            setTaskQuizMarksGate(null);
           }
         } else {
           setUserTeam(null);
+          setTaskQuizMarksGate(null);
         }
 
       } catch (err) {
@@ -269,6 +280,12 @@ const CompetitionDetails = () => {
     }
   };
 
+  const handleViewMarks = () => {
+    if (userTeam) {
+      navigate(`/competitions/${id}/team/${userTeam.team_id}/marks`);
+    }
+  };
+
   if (loading) {
     return <PageLoader />;
   }
@@ -449,6 +466,14 @@ const CompetitionDetails = () => {
                         <FiPlayCircle size={20} aria-hidden />
                         Open team workspace
                       </button>
+                      <button
+                        type="button"
+                        onClick={handleViewMarks}
+                        className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--secondary"
+                        style={{ display: taskQuizMarksGate?.can_view_marks ? 'inline-flex' : 'none' }}
+                      >
+                        View my marks
+                      </button>
                     </div>
                   ) : (
                     <div className="CompetitionDetailsPage__lockedNotice" style={{ marginTop: 10 }}>
@@ -497,24 +522,42 @@ const CompetitionDetails = () => {
                 <FiAward size={32} className="CompetitionDetailsPage__activeIcon" />
                 <h3>Competition is Live!</h3>
                 <p>Team: <strong>{userTeam.team_name}</strong></p>
-                <button
-                  onClick={handleStartCompetition}
-                  className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--primary"
-                >
-                  Access Team Workspace
-                </button>
+                <div className="CompetitionDetailsPage__regButtons">
+                  <button
+                    onClick={handleStartCompetition}
+                    className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--primary"
+                  >
+                    Access Team Workspace
+                  </button>
+                  <button
+                    onClick={handleViewMarks}
+                    className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--secondary"
+                    style={{ display: taskQuizMarksGate?.can_view_marks ? 'inline-flex' : 'none' }}
+                  >
+                    View my marks
+                  </button>
+                </div>
               </div>
             ) : isQuizUnlockedForView() ? (
               <div className="CompetitionDetailsPage__teamStatus">
                 <FiCheckCircle size={32} className="CompetitionDetailsPage__teamStatusIcon" />
                 <h3>You're Part of a Team</h3>
                 <p>Team: <strong>{userTeam.team_name}</strong></p>
-                <button
-                  onClick={handleViewTeam}
-                  className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--primary"
-                >
-                  Access Team Workspace
-                </button>
+                <div className="CompetitionDetailsPage__regButtons">
+                  <button
+                    onClick={handleViewTeam}
+                    className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--primary"
+                  >
+                    Access Team Workspace
+                  </button>
+                  <button
+                    onClick={handleViewMarks}
+                    className="CompetitionDetailsPage__btn CompetitionDetailsPage__btn--secondary"
+                    style={{ display: taskQuizMarksGate?.can_view_marks ? 'inline-flex' : 'none' }}
+                  >
+                    View my marks
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="CompetitionDetailsPage__lockedNotice">

--- a/client/src/pages/CompetitionWorkspace.jsx
+++ b/client/src/pages/CompetitionWorkspace.jsx
@@ -45,6 +45,7 @@ const CompetitionWorkspace = () => {
   const [tasks, setTasks] = useState([]);
   const [selectedTaskId, setSelectedTaskId] = useState(null);
   const [taskSubmissionMap, setTaskSubmissionMap] = useState({});
+  const [taskQuizMarksGate, setTaskQuizMarksGate] = useState(null);
   const [error, setError] = useState(null);
 
   // Form state
@@ -78,6 +79,7 @@ const CompetitionWorkspace = () => {
         if (!unlockedForView) {
           setTasks([]);
           setTaskSubmissionMap({});
+          setTaskQuizMarksGate(null);
           setSelectedTaskId(null);
           setSubmission(null);
         } else {
@@ -93,6 +95,10 @@ const CompetitionWorkspace = () => {
           );
           setTasks(list);
           setTaskSubmissionMap(map);
+          const marksData = await ApiService
+            .getMyTaskQuizEvaluation(competitionId, teamId)
+            .catch(() => null);
+          setTaskQuizMarksGate(marksData?.readiness || null);
           setSelectedTaskId((prev) =>
             prev != null && list.some((x) => x.task_id === prev) ? prev : list[0]?.task_id ?? null
           );
@@ -101,11 +107,13 @@ const CompetitionWorkspace = () => {
         setTasks([]);
         setSelectedTaskId(null);
         setTaskSubmissionMap({});
+        setTaskQuizMarksGate(null);
         setSubmission(null);
       } else {
         setTasks([]);
         setSelectedTaskId(null);
         setTaskSubmissionMap({});
+        setTaskQuizMarksGate(null);
         const submissionData = await ApiService
           .getTeamSubmission(competitionId, teamId)
           .catch(() => null);
@@ -494,6 +502,17 @@ const CompetitionWorkspace = () => {
           {competition?.end_at && (
             <div className="CompetitionWorkspace__deadlineBox">
               <span>Deadline: {formatDateTime(competition.end_at)}</span>
+            </div>
+          )}
+          {isTaskQuiz && taskQuizMarksGate?.can_view_marks === true && (
+            <div className="CompetitionWorkspace__deadlineBox" style={{ marginTop: 8 }}>
+              <button
+                type="button"
+                className="CompetitionWorkspace__quizBtnSecondary"
+                onClick={() => navigate(`/competitions/${competitionId}/team/${teamId}/marks`)}
+              >
+                View my marks
+              </button>
             </div>
           )}
         </motion.header>

--- a/client/src/pages/TaskQuizMarks.css
+++ b/client/src/pages/TaskQuizMarks.css
@@ -1,0 +1,113 @@
+.TaskQuizMarks {
+  width: min(1000px, 94%);
+  margin: 24px auto 56px;
+}
+
+.TaskQuizMarks__container {
+  background: rgba(15, 20, 32, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 22px;
+}
+
+.TaskQuizMarks__title {
+  margin: 0 0 16px;
+  color: #eaf2ff;
+}
+
+.TaskQuizMarks__notice {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  background: rgba(3, 169, 244, 0.12);
+  border: 1px solid rgba(3, 169, 244, 0.35);
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 18px;
+  color: #d9ecff;
+}
+
+.TaskQuizMarks__notice p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.TaskQuizMarks__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.TaskQuizMarks__summaryCard {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #d6e6fb;
+}
+
+.TaskQuizMarks__summaryCard strong {
+  color: #ffffff;
+  font-size: 1.2rem;
+}
+
+.TaskQuizMarks__list {
+  display: grid;
+  gap: 10px;
+}
+
+.TaskQuizMarks__item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.TaskQuizMarks__itemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.TaskQuizMarks__itemHeader h3 {
+  margin: 0;
+  color: #eaf2ff;
+  font-size: 1rem;
+}
+
+.TaskQuizMarks__score {
+  margin: 10px 0 0;
+  color: #c8d8ef;
+}
+
+.TaskQuizMarks__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.TaskQuizMarks__badge--done {
+  color: #b7ffd2;
+  background: rgba(34, 197, 94, 0.15);
+}
+
+.TaskQuizMarks__badge--pending {
+  color: #ffe9b3;
+  background: rgba(251, 191, 36, 0.16);
+}
+
+.TaskQuizMarks__error {
+  color: #ffd3d3;
+  background: rgba(220, 38, 38, 0.15);
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  border-radius: 10px;
+  padding: 10px 12px;
+}

--- a/client/src/pages/TaskQuizMarks.jsx
+++ b/client/src/pages/TaskQuizMarks.jsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ApiService from '../services/api';
+import SEO from '../components/SEO';
+import PageLoader from '../components/PageLoader';
+import BackButton from '../components/BackButton';
+import { FiInfo, FiCheckCircle, FiClock } from 'react-icons/fi';
+import './TaskQuizMarks.css';
+
+const TaskQuizMarks = () => {
+  const { id: competitionId, teamId } = useParams();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [payload, setPayload] = useState(null);
+
+  const loadMarks = useCallback(async ({ withSpinner = true } = {}) => {
+    if (withSpinner) setLoading(true);
+    try {
+      setError(null);
+      const data = await ApiService.getMyTaskQuizEvaluation(competitionId, teamId);
+      setPayload(data);
+    } catch (err) {
+      setError(err.message || 'Failed to load marks');
+    } finally {
+      if (withSpinner) setLoading(false);
+    }
+  }, [competitionId, teamId]);
+
+  useEffect(() => {
+    const run = async () => {
+      if (!ApiService.isAuthenticated()) {
+        navigate('/login', { replace: true });
+        return;
+      }
+      await loadMarks();
+    };
+    run();
+  }, [competitionId, teamId, navigate, loadMarks]);
+
+  useEffect(() => {
+    if (!payload?.readiness?.can_view_marks || payload?.readiness?.judges_evaluation_completed) return undefined;
+    const timer = setInterval(() => {
+      loadMarks({ withSpinner: false });
+    }, 20000);
+    return () => clearInterval(timer);
+  }, [payload?.readiness?.can_view_marks, payload?.readiness?.judges_evaluation_completed, loadMarks]);
+
+  if (loading) return <PageLoader />;
+  const readiness = payload?.readiness || {};
+  const canViewMarks = readiness.can_view_marks === true;
+  const fullMarksReady = readiness.judges_evaluation_completed === true;
+
+  return (
+    <section className="TaskQuizMarks">
+      <BackButton to={`/competitions/${competitionId}/team/${teamId}`} label="Back to Workspace" />
+      <SEO title="My Task Quiz Marks" description="Your task quiz marks and evaluation status." />
+
+      <div className="TaskQuizMarks__container">
+        <h1 className="TaskQuizMarks__title">{payload?.competition?.title || 'Task Quiz Marks'}</h1>
+
+        {error ? (
+          <div className="TaskQuizMarks__error">{error}</div>
+        ) : !canViewMarks ? (
+          <div className="TaskQuizMarks__notice">
+            <FiClock size={18} />
+            <p>
+              Your marks will appear after all tasks are submitted and automated code evaluation is complete for every task.
+              Progress: {readiness.submitted_tasks_count || 0}/{readiness.tasks_total || 0} tasks submitted,{' '}
+              {readiness.auto_evaluated_tasks_count || 0}/{readiness.tasks_total || 0} auto-evaluated.
+            </p>
+          </div>
+        ) : (
+          <>
+            {!fullMarksReady ? (
+              <div className="TaskQuizMarks__notice">
+                <FiInfo size={18} />
+                <p>
+                  These are <strong>code-evaluation marks only</strong> (the 40% automated part). Judges will evaluate your
+                  submissions soon, and this page will update automatically with your full final mark.
+                </p>
+              </div>
+            ) : (
+              <div className="TaskQuizMarks__notice">
+                <FiCheckCircle size={18} />
+                <p>
+                  This is your <strong>full final mark</strong> after judges evaluation (automated code evaluation + judges scores).
+                </p>
+              </div>
+            )}
+            <div className="TaskQuizMarks__summary">
+              <div className="TaskQuizMarks__summaryCard">
+                <span>Average static-analysis mark</span>
+                <strong>
+                  {payload?.average_static_analysis_score != null
+                    ? `${payload.average_static_analysis_score}/100`
+                    : 'Pending'}
+                </strong>
+              </div>
+              <div className="TaskQuizMarks__summaryCard">
+                <span>40% weighted portion</span>
+                <strong>
+                  {payload?.average_static_analysis_score != null
+                    ? `${Math.round(payload.average_static_analysis_score * 0.4 * 100) / 100}/40`
+                    : 'Pending'}
+                </strong>
+              </div>
+              <div className="TaskQuizMarks__summaryCard">
+                <span>Final mark after judges</span>
+                <strong>
+                  {payload?.average_final_score != null ? `${payload.average_final_score}/100` : 'Pending judges'}
+                </strong>
+              </div>
+            </div>
+
+            <div className="TaskQuizMarks__list">
+              {(payload?.task_marks || []).map((task) => (
+                <article key={task.task_id} className="TaskQuizMarks__item">
+                  <div className="TaskQuizMarks__itemHeader">
+                    <h3>{task.task_title || `Task ${task.task_id}`}</h3>
+                    {fullMarksReady ? (
+                      <span className="TaskQuizMarks__badge TaskQuizMarks__badge--done">
+                        <FiCheckCircle size={14} />
+                        Finalized
+                      </span>
+                    ) : task.static_analysis_score != null ? (
+                      <span className="TaskQuizMarks__badge TaskQuizMarks__badge--done">
+                        <FiCheckCircle size={14} />
+                        Evaluated
+                      </span>
+                    ) : (
+                      <span className="TaskQuizMarks__badge TaskQuizMarks__badge--pending">
+                        <FiClock size={14} />
+                        Pending
+                      </span>
+                    )}
+                  </div>
+                  <p className="TaskQuizMarks__score">
+                    Static-analysis mark:{' '}
+                    <strong>
+                      {task.static_analysis_score != null ? `${task.static_analysis_score}/100` : 'Not available yet'}
+                    </strong>
+                  </p>
+                  <p className="TaskQuizMarks__score">
+                    Final mark after judges:{' '}
+                    <strong>{task.final_score != null ? `${task.final_score}/100` : 'Pending judges'}</strong>
+                  </p>
+                </article>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default TaskQuizMarks;

--- a/server/controllers/evaluation.controller.js
+++ b/server/controllers/evaluation.controller.js
@@ -1,4 +1,12 @@
-const { Submission, Evaluation, JudgeScore, User, Team, Competition } = require('../models');
+const {
+  Submission,
+  Evaluation,
+  JudgeScore,
+  User,
+  Team,
+  Competition,
+  CompetitionTask
+} = require('../models');
 const { runEvaluationForSubmission } = require('../services/evaluationRunner');
 const {
   meanJudgeScore,
@@ -230,8 +238,320 @@ const getEvaluation = async (req, res) => {
   }
 };
 
+/**
+ * GET /api/evaluation/task-quiz/:competitionId/team/:teamId
+ * Returns per-task marks and average for task_quiz + hybrid/auto/manual judging.
+ */
+const getTaskQuizTeamEvaluation = async (req, res) => {
+  const competitionId = parseInt(req.params.competitionId, 10);
+  const teamId = parseInt(req.params.teamId, 10);
+  if (Number.isNaN(competitionId) || Number.isNaN(teamId)) {
+    return res.status(400).json({ success: false, error: 'Invalid competition or team id' });
+  }
+
+  try {
+    const competition = await Competition.findByPk(competitionId, {
+      attributes: ['competition_id', 'title', 'type', 'evaluation_mode']
+    });
+    if (!competition) {
+      return res.status(404).json({ success: false, error: 'Competition not found' });
+    }
+    if (competition.type !== 'task_quiz') {
+      return res.status(400).json({
+        success: false,
+        error: 'This endpoint is only available for task_quiz competitions'
+      });
+    }
+
+    const team = await Team.findOne({
+      where: { team_id: teamId, competition_id: competitionId },
+      attributes: ['team_id', 'team_name']
+    });
+    if (!team) {
+      return res.status(404).json({
+        success: false,
+        error: 'Team not found in this competition'
+      });
+    }
+
+    const tasks = await CompetitionTask.findAll({
+      where: { competition_id: competitionId },
+      attributes: ['task_id', 'title', 'position'],
+      order: [['position', 'ASC'], ['task_id', 'ASC']]
+    });
+
+    const submissions = await Submission.findAll({
+      where: {
+        competition_id: competitionId,
+        team_id: teamId
+      },
+      include: [
+        { model: Evaluation, as: 'evaluation' },
+        { model: JudgeScore, as: 'judgeScores' }
+      ],
+      order: [['task_id', 'ASC']]
+    });
+
+    const submissionsByTask = new Map();
+    for (const submission of submissions) {
+      if (submission.task_id != null) {
+        submissionsByTask.set(submission.task_id, submission);
+      }
+    }
+
+    const taskMarks = tasks.map((task) => {
+      const submission = submissionsByTask.get(task.task_id) || null;
+      if (!submission) {
+        return {
+          task_id: task.task_id,
+          task_title: task.title,
+          position: task.position,
+          submission_id: null,
+          status: 'missing',
+          auto_score: null,
+          judge_average: null,
+          final_score: null
+        };
+      }
+
+      const judgeRows = (submission.judgeScores || []).map((j) => j.toJSON());
+      const judgeAvg = meanJudgeScore(judgeRows);
+      const autoRaw = submission.evaluation
+        ? parseFloat(submission.evaluation.total_auto_score)
+        : null;
+      const autoScore = Number.isNaN(autoRaw) ? null : autoRaw;
+      const finalScore = computeFinalScore(autoScore, judgeAvg);
+
+      return {
+        task_id: task.task_id,
+        task_title: task.title,
+        position: task.position,
+        submission_id: submission.submission_id,
+        status: submission.status,
+        auto_score: autoScore,
+        judge_average: judgeAvg,
+        final_score: finalScore
+      };
+    });
+
+    const scoredTasks = taskMarks.filter((x) => x.final_score != null);
+    const averageFinalScore = scoredTasks.length
+      ? Math.round(
+          (scoredTasks.reduce((acc, row) => acc + row.final_score, 0) / scoredTasks.length) * 100
+        ) / 100
+      : null;
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        competition: {
+          competition_id: competition.competition_id,
+          title: competition.title,
+          type: competition.type,
+          evaluation_mode: competition.evaluation_mode
+        },
+        team: {
+          team_id: team.team_id,
+          team_name: team.team_name
+        },
+        task_marks: taskMarks,
+        average_final_score: averageFinalScore
+      }
+    });
+  } catch (error) {
+    logError('evaluation.taskQuizTeam', error, { competitionId, teamId }, req);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to load task quiz team evaluation'
+    });
+  }
+};
+
+/**
+ * GET /api/evaluation/my-task-quiz/:competitionId/team/:teamId
+ * Competitor-safe view: per-task static analysis mark and average.
+ */
+const getMyTaskQuizEvaluation = async (req, res) => {
+  const competitionId = parseInt(req.params.competitionId, 10);
+  const teamId = parseInt(req.params.teamId, 10);
+  if (Number.isNaN(competitionId) || Number.isNaN(teamId)) {
+    return res.status(400).json({ success: false, error: 'Invalid competition or team id' });
+  }
+
+  try {
+    const isPrivileged = ['admin', 'board'].includes(req.user.role);
+    if (!isPrivileged) {
+      const membership = await Submission.sequelize.query(
+        `SELECT tm.team_member_id
+         FROM team_members tm
+         INNER JOIN teams t ON tm.team_id = t.team_id
+         WHERE tm.team_id = ? AND tm.user_id = ? AND t.competition_id = ?
+         LIMIT 1`,
+        {
+          replacements: [teamId, req.user.user_id, competitionId],
+          type: Submission.sequelize.QueryTypes.SELECT
+        }
+      );
+      if (!membership || membership.length === 0) {
+        return res.status(403).json({ success: false, error: 'Access denied' });
+      }
+    }
+
+    const competition = await Competition.findByPk(competitionId, {
+      attributes: ['competition_id', 'title', 'type', 'evaluation_mode']
+    });
+    if (!competition) {
+      return res.status(404).json({ success: false, error: 'Competition not found' });
+    }
+    if (competition.type !== 'task_quiz') {
+      return res.status(400).json({
+        success: false,
+        error: 'This endpoint is only available for task_quiz competitions'
+      });
+    }
+
+    const team = await Team.findOne({
+      where: { team_id: teamId, competition_id: competitionId },
+      attributes: ['team_id', 'team_name']
+    });
+    if (!team) {
+      return res.status(404).json({
+        success: false,
+        error: 'Team not found in this competition'
+      });
+    }
+
+    const tasks = await CompetitionTask.findAll({
+      where: { competition_id: competitionId },
+      attributes: ['task_id', 'title', 'position'],
+      order: [['position', 'ASC'], ['task_id', 'ASC']]
+    });
+
+    const submissions = await Submission.findAll({
+      where: {
+        competition_id: competitionId,
+        team_id: teamId
+      },
+      include: [
+        { model: Evaluation, as: 'evaluation' },
+        { model: JudgeScore, as: 'judgeScores' }
+      ],
+      order: [['task_id', 'ASC']]
+    });
+
+    const submissionsByTask = new Map();
+    for (const submission of submissions) {
+      if (submission.task_id != null) {
+        submissionsByTask.set(submission.task_id, submission);
+      }
+    }
+
+    const taskMarks = tasks.map((task) => {
+      const submission = submissionsByTask.get(task.task_id) || null;
+      if (!submission) {
+        return {
+          task_id: task.task_id,
+          task_title: task.title,
+          position: task.position,
+          submission_id: null,
+          status: 'missing',
+          static_analysis_score: null,
+          judge_average: null,
+          final_score: null
+        };
+      }
+
+      const judgeRows = (submission.judgeScores || []).map((j) => j.toJSON());
+      const judgeAverage = meanJudgeScore(judgeRows);
+      const autoRaw = submission.evaluation
+        ? parseFloat(submission.evaluation.total_auto_score)
+        : null;
+      const autoScore = Number.isNaN(autoRaw) ? null : autoRaw;
+      const finalScore = computeFinalScore(autoScore, judgeAverage);
+      return {
+        task_id: task.task_id,
+        task_title: task.title,
+        position: task.position,
+        submission_id: submission.submission_id,
+        status: submission.status,
+        static_analysis_score: autoScore,
+        judge_average: judgeAverage,
+        final_score: finalScore
+      };
+    });
+
+    const tasksTotal = taskMarks.length;
+    const submittedTasksCount = taskMarks.filter((x) => x.submission_id != null).length;
+    const autoEvaluatedTasksCount = taskMarks.filter((x) => x.static_analysis_score != null).length;
+    const judgeEvaluatedTasksCount = taskMarks.filter((x) => x.judge_average != null).length;
+    const allTasksSubmitted = tasksTotal > 0 && submittedTasksCount === tasksTotal;
+    const autoEvaluationCompleted = allTasksSubmitted && autoEvaluatedTasksCount === tasksTotal;
+    const judgesEvaluationCompleted = autoEvaluationCompleted && judgeEvaluatedTasksCount === tasksTotal;
+
+    const scoredTasks = taskMarks.filter((x) => x.static_analysis_score != null);
+    const averageStaticAnalysisScore = scoredTasks.length
+      ? Math.round(
+          (scoredTasks.reduce((acc, row) => acc + row.static_analysis_score, 0) / scoredTasks.length) *
+            100
+        ) / 100
+      : null;
+    const finalScoredTasks = taskMarks.filter((x) => x.final_score != null);
+    const averageFinalScore = judgesEvaluationCompleted && finalScoredTasks.length > 0
+      ? Math.round(
+          (finalScoredTasks.reduce((acc, row) => acc + row.final_score, 0) / finalScoredTasks.length) *
+            100
+        ) / 100
+      : null;
+    const phase = !allTasksSubmitted
+      ? 'awaiting_submissions'
+      : !autoEvaluationCompleted
+        ? 'awaiting_auto_evaluation'
+        : !judgesEvaluationCompleted
+          ? 'awaiting_judges'
+          : 'complete';
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        competition: {
+          competition_id: competition.competition_id,
+          title: competition.title,
+          type: competition.type,
+          evaluation_mode: competition.evaluation_mode
+        },
+        team: {
+          team_id: team.team_id,
+          team_name: team.team_name
+        },
+        readiness: {
+          tasks_total: tasksTotal,
+          submitted_tasks_count: submittedTasksCount,
+          auto_evaluated_tasks_count: autoEvaluatedTasksCount,
+          judge_evaluated_tasks_count: judgeEvaluatedTasksCount,
+          all_tasks_submitted: allTasksSubmitted,
+          auto_evaluation_completed: autoEvaluationCompleted,
+          judges_evaluation_completed: judgesEvaluationCompleted,
+          can_view_marks: autoEvaluationCompleted,
+          phase
+        },
+        task_marks: taskMarks,
+        average_static_analysis_score: averageStaticAnalysisScore,
+        average_final_score: averageFinalScore
+      }
+    });
+  } catch (error) {
+    logError('evaluation.myTaskQuiz', error, { competitionId, teamId }, req);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to load your task quiz marks'
+    });
+  }
+};
+
 module.exports = {
   runEvaluation,
   submitJudgeScore,
-  getEvaluation
+  getEvaluation,
+  getTaskQuizTeamEvaluation,
+  getMyTaskQuizEvaluation
 };

--- a/server/routes/evaluation.routes.js
+++ b/server/routes/evaluation.routes.js
@@ -4,7 +4,9 @@ const { authenticateToken, verifyRole } = require('../middlewares/auth');
 const {
   runEvaluation,
   submitJudgeScore,
-  getEvaluation
+  getEvaluation,
+  getTaskQuizTeamEvaluation,
+  getMyTaskQuizEvaluation
 } = require('../controllers/evaluation.controller');
 
 router.post(
@@ -19,6 +21,19 @@ router.post(
   authenticateToken,
   verifyRole('admin', 'board'),
   submitJudgeScore
+);
+
+router.get(
+  '/task-quiz/:competitionId/team/:teamId',
+  authenticateToken,
+  verifyRole('admin', 'board'),
+  getTaskQuizTeamEvaluation
+);
+
+router.get(
+  '/my-task-quiz/:competitionId/team/:teamId',
+  authenticateToken,
+  getMyTaskQuizEvaluation
 );
 
 router.get(


### PR DESCRIPTION
- Introduced state management for task quiz marks in CompetitionDetails and CompetitionWorkspace components, allowing users to view their marks based on competition type.
- Implemented API calls to fetch task quiz evaluations, enhancing the user experience by providing timely feedback on performance.
- Added a new TaskQuizMarks component to display detailed marks and evaluation status, improving clarity for users.
- Created corresponding CSS styles for the TaskQuizMarks component to ensure a visually appealing layout.
- Updated server-side evaluation logic to support task quiz evaluations, ensuring accurate data retrieval for users.