### PR TITLE
Enhance competition submission logic to enforce team leader restrictions

### DIFF
--- a/client/src/pages/CompetitionWorkspace.jsx
+++ b/client/src/pages/CompetitionWorkspace.jsx
@@ -41,6 +41,7 @@ const CompetitionWorkspace = () => {
   const [submitting, setSubmitting] = useState(false);
   const [competition, setCompetition] = useState(null);
   const [team, setTeam] = useState(null);
+  const [currentUserId, setCurrentUserId] = useState(null);
   const [submission, setSubmission] = useState(null);
   const [tasks, setTasks] = useState([]);
   const [selectedTaskId, setSelectedTaskId] = useState(null);
@@ -61,13 +62,15 @@ const CompetitionWorkspace = () => {
       setLoading(true);
       setError(null);
 
-      const [competitionData, teamData] = await Promise.all([
+      const [competitionData, teamData, userProfile] = await Promise.all([
         ApiService.getCompetitionById(competitionId),
         ApiService.getTeamById(teamId),
+        ApiService.getProfile(),
       ]);
 
       setCompetition(competitionData);
       setTeam(teamData);
+      setCurrentUserId(userProfile?.user_id || null);
 
       if (competitionData?.type === 'task_quiz') {
         const now = new Date();
@@ -322,6 +325,12 @@ const CompetitionWorkspace = () => {
   const canSubmit = () => {
     if (!competition) return false;
     if (competition.type === 'quiz') return false;
+
+    const isLeader = !!team?.members?.some(
+      (m) => m?.user_id === currentUserId && String(m?.role).toLowerCase() === 'leader'
+    );
+    if (['project', 'task_quiz'].includes(competition.type) && !isLeader) return false;
+
     if (competition.type === 'task_quiz') {
       if (!tasks.length || selectedTaskId == null) return false;
       const now = new Date();
@@ -349,6 +358,9 @@ const CompetitionWorkspace = () => {
     return now < end;
   };
   const allowedSubmitTypes = getAllowedSubmitTypes();
+  const isCurrentUserLeader = !!team?.members?.some(
+    (m) => m?.user_id === currentUserId && String(m?.role).toLowerCase() === 'leader'
+  );
   const isFrontendMultitask = competition?.type === 'project' && competition?.config?.multiTask === true;
   const isClassicQuiz = competition?.type === 'quiz';
   const isTaskQuiz = competition?.type === 'task_quiz';
@@ -852,7 +864,9 @@ const CompetitionWorkspace = () => {
                 <div className="CompetitionWorkspace__alert CompetitionWorkspace__alert--warning">
                   <FiAlertCircle size={18} />
                   <span>
-                    {competition?.type === 'external' || competition?.submission_mode === 'none'
+                    {!isCurrentUserLeader && ['project', 'task_quiz'].includes(competition?.type)
+                      ? 'Only the team leader can submit. You can still view team progress and marks.'
+                      : competition?.type === 'external' || competition?.submission_mode === 'none'
                       ? 'This is an external competition. Submissions are disabled.'
                       : competition?.status !== 'open'
                       ? 'Competition is not open for submissions'

--- a/server/controllers/submissions.js
+++ b/server/controllers/submissions.js
@@ -35,7 +35,7 @@ const createSubmission = async (req, res) => {
 
         // Check if user is team member
         const teamMembers = await db.query(
-            `SELECT tm.team_member_id, t.is_locked
+            `SELECT tm.team_member_id, tm.role, t.is_locked
              FROM team_members tm
              INNER JOIN teams t ON tm.team_id = t.team_id
              WHERE tm.team_id = ? AND tm.user_id = ?`,
@@ -51,6 +51,7 @@ const createSubmission = async (req, res) => {
                 error: 'You are not a member of this team'
             });
         }
+        const membership = teamMembers[0];
 
         // Check competition status
         const competitions = await db.query(
@@ -69,6 +70,13 @@ const createSubmission = async (req, res) => {
         }
 
         const competition = competitions[0];
+
+        if (['project', 'task_quiz'].includes(competition.type) && membership.role !== 'leader') {
+            return res.status(403).json({
+                success: false,
+                error: 'Only the team leader can submit for this competition type'
+            });
+        }
 
         if (competition.type === 'quiz') {
             return res.status(400).json({


### PR DESCRIPTION
- Added state management for the current user ID in CompetitionWorkspace to identify team leaders.
- Updated submission logic to restrict submissions for 'project' and 'task_quiz' competition types to team leaders only, improving access control.
- Enhanced error handling in the server-side submission controller to return appropriate messages when non-leaders attempt to submit.