### PR TITLE
Update User model to set default role for new users

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -51,7 +51,8 @@ const User = sequelize.define('User', {
   },
   role: {
     type: DataTypes.ENUM('member', 'board', 'admin', 'competitor', 'judge'),
-    allowNull: false
+    allowNull: false,
+    defaultValue: 'member'
   },
   is_active: {
     type: DataTypes.BOOLEAN,


### PR DESCRIPTION
- Added a default value of 'member' for the role field in the User model, ensuring new users are assigned a role upon creation.
- Maintained the existing constraint of not allowing null values for the role field, enhancing data integrity.