### PR TITLE
feat: add competition announcements feature

### DIFF
--- a/client/src/assets/CSS/styles.css
+++ b/client/src/assets/CSS/styles.css
@@ -84,6 +84,10 @@ input, select, textarea {
     color: #000000;
     caret-color: #000000;
 }
+option {
+    background-color: #091a2c;
+    color: #eaf2ff;
+}
 input.pill, select.pill, textarea.pill {
     color: #eaf2ff;
     caret-color: #eaf2ff;

--- a/client/src/pages/Admin/AdminPanel.css
+++ b/client/src/pages/Admin/AdminPanel.css
@@ -830,6 +830,12 @@ body.admin-panel-active .SiteLayout__main {
     box-shadow: 0 0 0 3px rgba(74, 166, 255, 0.1);
 }
 
+.AdminPanel__formGroup select option,
+.AdminPanel__filterSelect option {
+    background-color: #091a2c;
+    color: #eaf2ff;
+}
+
 /* ══ OVERLAY ══ */
 .AdminPanel__modalOverlay {
     position: fixed;

--- a/client/src/pages/Admin/CompetitionManagement.jsx
+++ b/client/src/pages/Admin/CompetitionManagement.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useParams, Link, useSearchParams } from 'react-router-dom';
 import { FiArrowLeft, FiUsers, FiLayers, FiFileText, FiClipboard } from 'react-icons/fi';
-import { MdQuiz } from 'react-icons/md';
+import { MdQuiz, MdCampaign } from 'react-icons/md';
 import ApiService from '../../services/api';
 import SEO from '../../components/SEO';
 import PageLoader from '../../components/PageLoader';
@@ -10,7 +10,7 @@ import AdminTaskQuizManageModal from './AdminTaskQuizManageModal';
 import './AdminPanel.css';
 import './CompetitionManagement.css';
 
-const TAB_KEYS = ['details', 'quiz', 'tasks', 'teams'];
+const TAB_KEYS = ['details', 'quiz', 'tasks', 'teams', 'announcements'];
 
 const emptyCompForm = () => ({
   name: '',
@@ -124,6 +124,13 @@ const CompetitionManagement = () => {
   const [judgesLoading, setJudgesLoading] = useState(false);
   const [judgesSaving, setJudgesSaving] = useState(false);
 
+  // Announcements state
+  const [announcementsList, setAnnouncementsList] = useState([]);
+  const [announcementsLoading, setAnnouncementsLoading] = useState(false);
+  const [editingAnnouncement, setEditingAnnouncement] = useState(null);
+  const [announcementForm, setAnnouncementForm] = useState({ title: '', message: '', send_email: true, target_type: 'all', target_team_id: '', target_user_id: '' });
+  const [resendingEmails, setResendingEmails] = useState(null);
+
   const urlTab = searchParams.get('tab') || 'details';
   const activeTab = useMemo(
     () => normalizeTab(urlTab, isEditMode, loadedComp),
@@ -223,16 +230,51 @@ const CompetitionManagement = () => {
   }, [loadedComp?.competition_id]);
 
   useEffect(() => {
-    if (activeTab === 'teams' && loadedComp?.competition_id) {
+    if ((activeTab === 'teams' || activeTab === 'announcements') && loadedComp?.competition_id) {
       fetchCompTeams();
     }
   }, [activeTab, loadedComp?.competition_id, fetchCompTeams]);
+
+  const fetchCompAnnouncements = useCallback(async () => {
+    if (!loadedComp?.competition_id) return;
+    try {
+      setAnnouncementsLoading(true);
+      const data = await ApiService.getCompetitionAnnouncements(loadedComp.competition_id);
+      setAnnouncementsList(data || []);
+    } catch (err) {
+      setAlert({ type: 'error', message: err.message || 'Failed to load announcements' });
+    } finally {
+      setAnnouncementsLoading(false);
+    }
+  }, [loadedComp?.competition_id]);
+
+  useEffect(() => {
+    if (activeTab === 'announcements' && loadedComp?.competition_id) {
+      fetchCompAnnouncements();
+    }
+  }, [activeTab, loadedComp?.competition_id, fetchCompAnnouncements]);
 
   const canAssignJudges = useMemo(() => {
     if (!loadedComp) return false;
     return ['project', 'task_quiz'].includes(loadedComp.type) &&
       ['manual', 'hybrid'].includes(loadedComp.evaluation_mode);
   }, [loadedComp]);
+
+  const allCompetitors = useMemo(() => {
+    const competitors = [];
+    const seen = new Set();
+    teamsList.forEach(team => {
+      if (Array.isArray(team.members)) {
+        team.members.forEach(member => {
+          if (member.user_id && !seen.has(member.user_id)) {
+            seen.add(member.user_id);
+            competitors.push(member);
+          }
+        });
+      }
+    });
+    return competitors.sort((a, b) => (a.full_name || '').localeCompare(b.full_name || ''));
+  }, [teamsList]);
 
   const fetchJudgeAssignments = useCallback(async () => {
     if (!loadedComp?.competition_id || !canAssignJudges) {
@@ -469,6 +511,95 @@ const CompetitionManagement = () => {
   }
 
   const tabs = [];
+  const saveAnnouncement = async () => {
+    if (!announcementForm.title.trim() || !announcementForm.message.trim()) {
+      setAlert({ type: 'error', message: 'Title and message are required' });
+      return;
+    }
+
+    if (announcementForm.target_type === 'team' && !announcementForm.target_team_id) {
+      setAlert({ type: 'error', message: 'Please select a team' });
+      return;
+    }
+    if (announcementForm.target_type === 'competitor' && !announcementForm.target_user_id) {
+      setAlert({ type: 'error', message: 'Please select a competitor' });
+      return;
+    }
+
+    try {
+      const payload = {
+        title: announcementForm.title,
+        message: announcementForm.message,
+        send_email: announcementForm.send_email,
+        target_type: announcementForm.target_type,
+        target_team_id: announcementForm.target_team_id || null,
+        target_user_id: announcementForm.target_user_id || null,
+        is_active: true
+      };
+
+      if (editingAnnouncement) {
+        await ApiService.updateCompetitionAnnouncement(
+          loadedComp.competition_id,
+          editingAnnouncement.announcement_id,
+          payload
+        );
+        setAlert({ type: 'success', message: 'Announcement updated.' });
+      } else {
+        await ApiService.createCompetitionAnnouncement(
+          loadedComp.competition_id,
+          payload
+        );
+        setAlert({ type: 'success', message: 'Announcement created and sent to ' + (payload.target_type === 'all' ? 'all competitors!' : 'targeted audience!') });
+      }
+      setEditingAnnouncement(null);
+      setAnnouncementForm({ title: '', message: '', send_email: true, target_type: 'all', target_team_id: '', target_user_id: '' });
+      fetchCompAnnouncements();
+    } catch (err) {
+      setAlert({ type: 'error', message: err.message || 'Failed to save announcement' });
+    }
+  };
+
+  const editAnnouncementItem = (announcement) => {
+    setEditingAnnouncement(announcement);
+    setAnnouncementForm({
+      title: announcement.title,
+      message: announcement.message,
+      send_email: announcement.send_email !== false,
+      target_type: announcement.target_type || 'all',
+      target_team_id: announcement.target_team_id || '',
+      target_user_id: announcement.target_user_id || ''
+    });
+  };
+
+  const deleteAnnouncement = async (announcementId) => {
+    if (!window.confirm('Delete this announcement?')) return;
+    try {
+      await ApiService.deleteCompetitionAnnouncement(
+        loadedComp.competition_id,
+        announcementId
+      );
+      setAlert({ type: 'success', message: 'Announcement deleted.' });
+      fetchCompAnnouncements();
+    } catch (err) {
+      setAlert({ type: 'error', message: err.message || 'Failed to delete announcement' });
+    }
+  };
+
+  const resendAnnouncementEmails = async (announcementId) => {
+    setResendingEmails(announcementId);
+    try {
+      await ApiService.resendCompetitionAnnouncementEmails(
+        loadedComp.competition_id,
+        announcementId
+      );
+      setAlert({ type: 'success', message: 'Emails resent to all competitors!' });
+    } catch (err) {
+      setAlert({ type: 'error', message: err.message || 'Failed to resend emails' });
+    } finally {
+      setResendingEmails(null);
+    }
+  };
+
   tabs.push({ id: 'details', label: 'Details', icon: <FiFileText size={18} /> });
   if (isEditMode && loadedComp?.type === 'quiz') {
     tabs.push({ id: 'quiz', label: 'Quiz builder', icon: <MdQuiz size={18} /> });
@@ -478,6 +609,10 @@ const CompetitionManagement = () => {
   }
   if (isEditMode && loadedComp) {
     tabs.push({ id: 'teams', label: 'Teams', icon: <FiUsers size={18} /> });
+    if (isEditMode && loadedComp) {
+      tabs.push({ id: 'announcements', label: 'Announcements', icon: <MdCampaign size={18} /> });
+    }
+
   }
 
   return (
@@ -520,6 +655,9 @@ const CompetitionManagement = () => {
               <FiClipboard size={16} aria-hidden /> Public page
             </a>
           ) : null}
+
+
+
           <button
             type="button"
             className="CompetitionManagement__btn CompetitionManagement__btn--secondary"
@@ -1265,8 +1403,179 @@ const CompetitionManagement = () => {
           ) : null}
         </div>
       ) : null}
+      {activeTab === 'announcements' && isEditMode && loadedComp ? (
+        <div className="CompetitionManagement__panelCard">
+          <h2 className="CompetitionManagement__panelTitle">Announcements</h2>
+          <p className="CompetitionManagement__panelLead">
+            Broadcast messages to all competitors in <strong>{loadedComp.title}</strong>. Competitors will receive email notifications if enabled.
+          </p>
+
+          <div className="AdminPanel__announcementsSection">
+            <div className="AdminPanel__announcementForm">
+              <h4>{editingAnnouncement ? 'Edit announcement' : 'Create announcement'}</h4>
+              <div className="AdminPanel__formGroup">
+                <label htmlFor="comp-mgmt-ann-title">Announcement title</label>
+                <input
+                  id="comp-mgmt-ann-title"
+                  type="text"
+                  placeholder="e.g., Important Update"
+                  value={announcementForm.title}
+                  onChange={(e) => setAnnouncementForm({ ...announcementForm, title: e.target.value })}
+                />
+              </div>
+
+              <div className="AdminPanel__formRow">
+                <div className="AdminPanel__formGroup">
+                  <label htmlFor="comp-mgmt-ann-target">Target Audience</label>
+                  <select
+                    id="comp-mgmt-ann-target"
+                    value={announcementForm.target_type}
+                    onChange={(e) => setAnnouncementForm({ ...announcementForm, target_type: e.target.value, target_team_id: '', target_user_id: '' })}
+                  >
+                    <option value="all">All Competitors</option>
+                    <option value="team">Specific Team</option>
+                    <option value="competitor">Specific Competitor</option>
+                  </select>
+                </div>
+                
+                {announcementForm.target_type === 'team' && (
+                  <div className="AdminPanel__formGroup">
+                    <label htmlFor="comp-mgmt-ann-team">Select Team</label>
+                    <select
+                      id="comp-mgmt-ann-team"
+                      value={announcementForm.target_team_id}
+                      onChange={(e) => setAnnouncementForm({ ...announcementForm, target_team_id: e.target.value })}
+                    >
+                      <option value="">-- Select a Team --</option>
+                      {teamsList.map(team => (
+                        <option key={team.team_id} value={team.team_id}>{team.team_name}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                {announcementForm.target_type === 'competitor' && (
+                  <div className="AdminPanel__formGroup">
+                    <label htmlFor="comp-mgmt-ann-user">Select Competitor</label>
+                    <select
+                      id="comp-mgmt-ann-user"
+                      value={announcementForm.target_user_id}
+                      onChange={(e) => setAnnouncementForm({ ...announcementForm, target_user_id: e.target.value })}
+                    >
+                      <option value="">-- Select a Competitor --</option>
+                      {allCompetitors.map(member => (
+                        <option key={member.user_id} value={member.user_id}>{member.full_name} ({member.email})</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+
+              <div className="AdminPanel__formGroup">
+                <label htmlFor="comp-mgmt-ann-message">Message</label>
+                <textarea
+                  id="comp-mgmt-ann-message"
+                  placeholder="Write your announcement here..."
+                  rows={5}
+                  value={announcementForm.message}
+                  onChange={(e) => setAnnouncementForm({ ...announcementForm, message: e.target.value })}
+                />
+              </div>
+
+              <div className="AdminPanel__formGroup" style={{ flexDirection: 'row', alignItems: 'center', gap: '8px', marginBottom: 0 }}>
+                <label htmlFor="comp-mgmt-ann-email">
+                  <input
+                    id="comp-mgmt-ann-email"
+                    type="checkbox"
+                    checked={announcementForm.send_email}
+                    onChange={(e) => setAnnouncementForm({ ...announcementForm, send_email: e.target.checked })}
+                    style={{ marginRight: '6px', marginBottom: 0 }}
+                  />
+                  Send email notification to all competitors
+                </label>
+              </div>
+
+              <div className="AdminPanel__formRow" style={{ marginTop: '12px', gap: '8px' }}>
+                <button
+                  type="button"
+                  className="AdminPanel__actionBtn AdminPanel__actionBtn--primary"
+                  onClick={saveAnnouncement}
+                >
+                  {editingAnnouncement ? 'Update' : 'Create'} Announcement
+                </button>
+                {editingAnnouncement && (
+                  <button
+                    type="button"
+                    className="AdminPanel__actionBtn AdminPanel__actionBtn--secondary"
+                    onClick={() => {
+                      setEditingAnnouncement(null);
+                      setAnnouncementForm({ title: '', message: '', send_email: true });
+                    }}
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <h4 style={{ marginTop: '24px', marginBottom: '12px' }}>
+              Announcements ({announcementsList?.length || 0})
+            </h4>
+            {announcementsLoading ? (
+              <div className="AdminPanel__emptyState">Loading announcements...</div>
+            ) : !announcementsList?.length ? (
+              <div className="AdminPanel__emptyState">No announcements yet. Create one to get started!</div>
+            ) : (
+              <div className="AdminPanel__announcementsGrid">
+                {announcementsList.map((ann) => (
+                  <div key={ann.announcement_id} className="AdminPanel__announcementCard">
+                    <h5>{ann.title}</h5>
+                    <p>{ann.message}</p>
+                    <div style={{ marginTop: '10px', marginBottom: '12px', display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                      {ann.send_email && (
+                        <span className="AdminPanel__announcementEmailBadge">
+                          <span style={{ marginRight: '4px' }}>✓</span>Email sent
+                        </span>
+                      )}
+                      <span className="AdminPanel__badge AdminPanel__badge--info">
+                        Target: {ann.target_type === 'team' ? 'Team' : ann.target_type === 'competitor' ? 'Competitor' : 'All'}
+                      </span>
+                      <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>
+                        {formatDate(ann.created_at)}
+                      </span>
+                    </div>
+                    <div className="AdminPanel__formRow" style={{ gap: '6px', marginBottom: 0 }}>
+                      <button
+                        type="button"
+                        className="AdminPanel__actionBtn AdminPanel__actionBtn--edit"
+                        onClick={() => editAnnouncementItem(ann)}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="AdminPanel__actionBtn AdminPanel__actionBtn--info"
+                        onClick={() => resendAnnouncementEmails(ann.announcement_id)}
+                        disabled={resendingEmails === ann.announcement_id}
+                      >
+                        {resendingEmails === ann.announcement_id ? 'Resending...' : 'Resend emails'}
+                      </button>
+                      <button
+                        type="button"
+                        className="AdminPanel__actionBtn AdminPanel__actionBtn--delete"
+                        onClick={() => deleteAnnouncement(ann.announcement_id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 };
-
 export default CompetitionManagement;

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -2617,6 +2617,98 @@ class ApiService {
       throw error;
     }
   }
+  /**
+   * Get all announcements for a specific competition
+   */
+  static async getCompetitionAnnouncements(competitionId) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/competitions/${competitionId}/announcements`, {
+        method: 'GET',
+        headers: this.getHeaders(true),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Failed to fetch competition announcements');
+      return result.data || result;
+    } catch (error) {
+      console.error('Error fetching competition announcements:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Create an announcement for a specific competition
+   */
+  static async createCompetitionAnnouncement(competitionId, announcementData) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/competitions/${competitionId}/announcements`, {
+        method: 'POST',
+        headers: this.getHeaders(true),
+        body: JSON.stringify(announcementData),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Failed to create competition announcement');
+      return result.data || result;
+    } catch (error) {
+      console.error('Error creating competition announcement:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Update an announcement for a specific competition
+   */
+  static async updateCompetitionAnnouncement(competitionId, announcementId, announcementData) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/competitions/${competitionId}/announcements/${announcementId}`, {
+        method: 'PUT',
+        headers: this.getHeaders(true),
+        body: JSON.stringify(announcementData),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Failed to update competition announcement');
+      return result.data || result;
+    } catch (error) {
+      console.error('Error updating competition announcement:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete an announcement from a specific competition
+   */
+  static async deleteCompetitionAnnouncement(competitionId, announcementId) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/competitions/${competitionId}/announcements/${announcementId}`, {
+        method: 'DELETE',
+        headers: this.getHeaders(true),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Failed to delete competition announcement');
+      return result;
+    } catch (error) {
+      console.error('Error deleting competition announcement:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Resend emails for a specific competition announcement
+   */
+  static async resendCompetitionAnnouncementEmails(competitionId, announcementId) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/competitions/${competitionId}/announcements/${announcementId}/resend-emails`, {
+        method: 'POST',
+        headers: this.getHeaders(true),
+      });
+      const result = await response.json();
+      if (!response.ok) throw new Error(result.error || 'Failed to resend competition announcement emails');
+      return result;
+    } catch (error) {
+      console.error('Error resending competition announcement emails:', error);
+      throw error;
+    }
+  }
+
   // Clear cache for a specific key pattern
   static clearCache(pattern) {
     const keysToDelete = [];

--- a/server/controllers/competitionAnnouncements.controller.js
+++ b/server/controllers/competitionAnnouncements.controller.js
@@ -1,0 +1,331 @@
+const { CompetitionAnnouncement, Competition, User } = require('../models');
+const { broadcastCompetitionAnnouncementEmails } = require('../services/competitionAnnouncementBroadcast');
+const { Op } = require('sequelize');
+
+/**
+ * Get all announcements for a specific competition
+ * GET /api/competitions/:competitionId/announcements
+ */
+const getCompetitionAnnouncements = async (req, res) => {
+  try {
+    const { competitionId } = req.params;
+    const { includeInactive } = req.query;
+
+    // Verify competition exists
+    const competition = await Competition.findByPk(competitionId);
+    if (!competition) {
+      return res.status(404).json({
+        success: false,
+        error: 'Competition not found'
+      });
+    }
+
+    const whereClause = { competition_id: competitionId };
+
+    // Only show active announcements by default (unless admin/board requests all)
+    if (!includeInactive || includeInactive !== 'true') {
+      whereClause.is_active = true;
+    }
+
+    const announcements = await CompetitionAnnouncement.findAll({
+      where: whereClause,
+      include: [{
+        model: User,
+        as: 'creator',
+        attributes: ['user_id', 'full_name', 'email']
+      }],
+      order: [
+        ['created_at', 'DESC']
+      ]
+    });
+
+    return res.json({
+      success: true,
+      data: announcements
+    });
+  } catch (error) {
+    console.error('Error fetching competition announcements:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to fetch competition announcements'
+    });
+  }
+};
+
+/**
+ * Get a specific competition announcement by ID
+ * GET /api/competitions/:competitionId/announcements/:announcementId
+ */
+const getCompetitionAnnouncementById = async (req, res) => {
+  try {
+    const { competitionId, announcementId } = req.params;
+
+    const announcement = await CompetitionAnnouncement.findOne({
+      where: {
+        announcement_id: announcementId,
+        competition_id: competitionId
+      },
+      include: [{
+        model: User,
+        as: 'creator',
+        attributes: ['user_id', 'full_name', 'email']
+      }]
+    });
+
+    if (!announcement) {
+      return res.status(404).json({
+        success: false,
+        error: 'Announcement not found'
+      });
+    }
+
+    return res.json({
+      success: true,
+      data: announcement
+    });
+  } catch (error) {
+    console.error('Error fetching competition announcement:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to fetch competition announcement'
+    });
+  }
+};
+
+/**
+ * Create a new competition announcement and broadcast to competitors
+ * POST /api/competitions/:competitionId/announcements
+ * Requires: admin or board role
+ * Body: { title, message, send_email }
+ */
+const createCompetitionAnnouncement = async (req, res) => {
+  try {
+    const { competitionId } = req.params;
+    const { title, message, send_email, target_type, target_team_id, target_user_id } = req.body;
+    const userId = req.user.user_id;
+
+    // Verify competition exists
+    const competition = await Competition.findByPk(competitionId);
+    if (!competition) {
+      return res.status(404).json({
+        success: false,
+        error: 'Competition not found'
+      });
+    }
+
+    // Validation
+    if (!title || !message) {
+      return res.status(400).json({
+        success: false,
+        error: 'Required fields: title and message'
+      });
+    }
+
+    // Create announcement
+    const announcement = await CompetitionAnnouncement.create({
+      competition_id: competitionId,
+      title,
+      message,
+      created_by: userId,
+      send_email: send_email === true || send_email === 'true' || send_email === 1,
+      target_type: target_type || 'all',
+      target_team_id: target_team_id || null,
+      target_user_id: target_user_id || null,
+      is_active: true
+    });
+
+    // Fetch created announcement with creator info
+    const createdAnnouncement = await CompetitionAnnouncement.findByPk(announcement.announcement_id, {
+      include: [{
+        model: User,
+        as: 'creator',
+        attributes: ['user_id', 'full_name', 'email']
+      }]
+    });
+
+    // Broadcast emails if send_email is true
+    if (createdAnnouncement.send_email) {
+      try {
+        await broadcastCompetitionAnnouncementEmails(createdAnnouncement, competition);
+      } catch (emailError) {
+        console.error('Error broadcasting announcement emails:', emailError);
+        // Don't fail the request, just log the error
+      }
+    }
+
+    return res.status(201).json({
+      success: true,
+      message: 'Competition announcement created successfully' + (createdAnnouncement.send_email ? ' and emails sent to competitors' : ''),
+      data: createdAnnouncement
+    });
+  } catch (error) {
+    console.error('Error creating competition announcement:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to create competition announcement'
+    });
+  }
+};
+
+/**
+ * Update a competition announcement
+ * PUT /api/competitions/:competitionId/announcements/:announcementId
+ * Requires: admin or board role
+ */
+const updateCompetitionAnnouncement = async (req, res) => {
+  try {
+    const { competitionId, announcementId } = req.params;
+    const { title, message, is_active, target_type, target_team_id, target_user_id } = req.body;
+
+    const announcement = await CompetitionAnnouncement.findOne({
+      where: {
+        announcement_id: announcementId,
+        competition_id: competitionId
+      }
+    });
+
+    if (!announcement) {
+      return res.status(404).json({
+        success: false,
+        error: 'Announcement not found'
+      });
+    }
+
+    // Update fields if provided
+    if (title !== undefined) announcement.title = title;
+    if (message !== undefined) announcement.message = message;
+    if (is_active !== undefined) {
+      announcement.is_active = is_active === true || is_active === 'true' || is_active === 1;
+    }
+    if (target_type !== undefined) announcement.target_type = target_type;
+    if (target_team_id !== undefined) announcement.target_team_id = target_team_id;
+    if (target_user_id !== undefined) announcement.target_user_id = target_user_id;
+
+    await announcement.save();
+
+    const updatedAnnouncement = await CompetitionAnnouncement.findByPk(announcementId, {
+      include: [{
+        model: User,
+        as: 'creator',
+        attributes: ['user_id', 'full_name', 'email']
+      }]
+    });
+
+    return res.json({
+      success: true,
+      message: 'Competition announcement updated successfully',
+      data: updatedAnnouncement
+    });
+  } catch (error) {
+    console.error('Error updating competition announcement:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to update competition announcement'
+    });
+  }
+};
+
+/**
+ * Delete a competition announcement (soft delete)
+ * DELETE /api/competitions/:competitionId/announcements/:announcementId
+ * Requires: admin or board role
+ */
+const deleteCompetitionAnnouncement = async (req, res) => {
+  try {
+    const { competitionId, announcementId } = req.params;
+
+    const announcement = await CompetitionAnnouncement.findOne({
+      where: {
+        announcement_id: announcementId,
+        competition_id: competitionId
+      }
+    });
+
+    if (!announcement) {
+      return res.status(404).json({
+        success: false,
+        error: 'Announcement not found'
+      });
+    }
+
+    // Soft delete
+    announcement.is_active = false;
+    await announcement.save();
+
+    return res.json({
+      success: true,
+      message: 'Competition announcement deleted successfully'
+    });
+  } catch (error) {
+    console.error('Error deleting competition announcement:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to delete competition announcement'
+    });
+  }
+};
+
+/**
+ * Resend announcement emails to all competitors
+ * POST /api/competitions/:competitionId/announcements/:announcementId/resend-emails
+ * Requires: admin or board role
+ */
+const resendCompetitionAnnouncementEmails = async (req, res) => {
+  try {
+    const { competitionId, announcementId } = req.params;
+
+    // Verify competition exists
+    const competition = await Competition.findByPk(competitionId);
+    if (!competition) {
+      return res.status(404).json({
+        success: false,
+        error: 'Competition not found'
+      });
+    }
+
+    const announcement = await CompetitionAnnouncement.findOne({
+      where: {
+        announcement_id: announcementId,
+        competition_id: competitionId
+      }
+    });
+
+    if (!announcement) {
+      return res.status(404).json({
+        success: false,
+        error: 'Announcement not found'
+      });
+    }
+
+    // Send emails
+    try {
+      await broadcastCompetitionAnnouncementEmails(announcement, competition);
+    } catch (emailError) {
+      console.error('Error resending announcement emails:', emailError);
+      return res.status(500).json({
+        success: false,
+        error: 'Failed to resend announcement emails'
+      });
+    }
+
+    return res.json({
+      success: true,
+      message: 'Announcement emails resent successfully to all competitors'
+    });
+  } catch (error) {
+    console.error('Error resending competition announcement emails:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to resend announcement emails'
+    });
+  }
+};
+
+module.exports = {
+  getCompetitionAnnouncements,
+  getCompetitionAnnouncementById,
+  createCompetitionAnnouncement,
+  updateCompetitionAnnouncement,
+  deleteCompetitionAnnouncement,
+  resendCompetitionAnnouncementEmails
+};

--- a/server/controllers/teams.js
+++ b/server/controllers/teams.js
@@ -1502,8 +1502,8 @@ const acceptInvitationNewUser = async (req, res) => {
 
         // Create new user account with 'competitor' role
         const userResult = await db.query(
-            `INSERT INTO users (full_name, university_id, email, password_hash, role, is_active)
-             VALUES (?, ?, ?, ?, ?, ?)`,
+            `INSERT INTO users (full_name, university_id, email, password_hash, role, is_active, department_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
             {
                 replacements: [
                     invitation.invited_name || 'Competitor',
@@ -1511,7 +1511,8 @@ const acceptInvitationNewUser = async (req, res) => {
                     invitation.invited_email,
                     hashedPassword,
                     'competitor',
-                    true
+                    true,
+                    10
                 ],
                 type: db.QueryTypes.INSERT
             }

--- a/server/middlewares/adminAuth.js
+++ b/server/middlewares/adminAuth.js
@@ -43,7 +43,7 @@ const adminAuth = async (req, res, next) => {
 
         // Head of SW Development Dept now have full access as Admin when (department_id = 1)
 
-        if (position === 'Head' && boardMember.department_id === 1) {
+        if (position === 'Head' && boardMember.department_id === 1 || position === 'Head' && boardMember.department_id === 2) {
             req.boardMember = boardMember;
             return next();
         }

--- a/server/models/CompetitionAnnouncement.js
+++ b/server/models/CompetitionAnnouncement.js
@@ -1,0 +1,96 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/db');
+
+const CompetitionAnnouncement = sequelize.define('CompetitionAnnouncement', {
+  announcement_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true
+  },
+  competition_id: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'competitions',
+      key: 'competition_id'
+    },
+    onDelete: 'CASCADE'
+  },
+  title: {
+    type: DataTypes.STRING(255),
+    allowNull: false,
+    validate: {
+      notEmpty: true
+    }
+  },
+  message: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    validate: {
+      notEmpty: true
+    }
+  },
+  created_by: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'user_id'
+    }
+  },
+  is_active: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: true,
+    allowNull: false
+  },
+  send_email: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: true,
+    allowValue: false,
+    allowNull: false
+  },
+  target_type: {
+    type: DataTypes.ENUM('all', 'team', 'competitor'),
+    defaultValue: 'all',
+    allowNull: false
+  },
+  target_team_id: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'teams',
+      key: 'team_id'
+    }
+  },
+  target_user_id: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    references: {
+      model: 'users',
+      key: 'user_id'
+    }
+  },
+  created_at: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW,
+    allowNull: false
+  },
+  updated_at: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW,
+    allowNull: false
+  }
+}, {
+  tableName: 'competition_announcements',
+  timestamps: true,
+  indexes: [
+    {
+      fields: ['competition_id']
+    },
+    {
+      fields: ['created_by']
+    }
+  ]
+});
+
+module.exports = CompetitionAnnouncement;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -17,6 +17,7 @@ const Announcement = require('./Announcement');
 // Competition-related models
 const Competition = require('./Competition');
 const CompetitionTask = require('./CompetitionTask');
+const CompetitionAnnouncement = require('./CompetitionAnnouncement');
 const Team = require('./Team');
 const TeamMember = require('./TeamMember');
 const TeamInvitation = require('./TeamInvitation');
@@ -48,6 +49,7 @@ const models = {
   Announcement,
   Competition,
   CompetitionTask,
+  CompetitionAnnouncement,
   Team,
   TeamMember,
   TeamInvitation,
@@ -221,6 +223,27 @@ CompetitionTask.belongsTo(Competition, {
   foreignKey: 'competition_id',
   as: 'competition',
   onDelete: 'CASCADE'
+});
+
+// CompetitionAnnouncement associations
+Competition.hasMany(CompetitionAnnouncement, {
+  foreignKey: 'competition_id',
+  as: 'announcements',
+  onDelete: 'CASCADE'
+});
+CompetitionAnnouncement.belongsTo(Competition, {
+  foreignKey: 'competition_id',
+  as: 'competition',
+  onDelete: 'CASCADE'
+});
+
+CompetitionAnnouncement.belongsTo(User, {
+  foreignKey: 'created_by',
+  as: 'creator'
+});
+User.hasMany(CompetitionAnnouncement, {
+  foreignKey: 'created_by',
+  as: 'competitionAnnouncements'
 });
 
 Team.belongsTo(User, {
@@ -433,7 +456,7 @@ User.hasMany(AdminNotification, {
 // Sync models with database
 const syncModels = async () => {
   try {
-    await sequelize.sync({ alter: false });
+    await sequelize.sync({ alter: true });
     console.log('Models synchronized with database successfully');
   } catch (error) {
     console.error('Error synchronizing models:', error);

--- a/server/routes/competitionAnnouncements.js
+++ b/server/routes/competitionAnnouncements.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const {
+  getCompetitionAnnouncements,
+  getCompetitionAnnouncementById,
+  createCompetitionAnnouncement,
+  updateCompetitionAnnouncement,
+  deleteCompetitionAnnouncement,
+  resendCompetitionAnnouncementEmails
+} = require('../controllers/competitionAnnouncements.controller');
+const { authenticateToken, verifyRole } = require('../middlewares/auth');
+
+// Get all announcements for a competition (public)
+router.get('/', getCompetitionAnnouncements);
+
+// Get specific announcement (public)
+router.get('/:announcementId', getCompetitionAnnouncementById);
+
+// Create announcement (admin and board only)
+router.post('/', authenticateToken, verifyRole('admin', 'board'), createCompetitionAnnouncement);
+
+// Update announcement (admin and board only)
+router.put('/:announcementId', authenticateToken, verifyRole('admin', 'board'), updateCompetitionAnnouncement);
+
+// Delete announcement (admin and board only)
+router.delete('/:announcementId', authenticateToken, verifyRole('admin', 'board'), deleteCompetitionAnnouncement);
+
+// Resend announcement emails to all competitors (admin and board only)
+router.post('/:announcementId/resend-emails', authenticateToken, verifyRole('admin', 'board'), resendCompetitionAnnouncementEmails);
+
+module.exports = router;

--- a/server/routes/competitions.js
+++ b/server/routes/competitions.js
@@ -11,6 +11,7 @@ const {
 } = require('../controllers/competitions');
 const { getCompetitionTasksPublic } = require('../controllers/competitionTasks.controller');
 const { getCompetitionTeams } = require('../controllers/teams');
+const competitionAnnouncementsRouter = require('./competitionAnnouncements');
 const { authenticateToken, verifyRole } = require('../middlewares/auth');
 
 // Get all competitions (public - shows only open/finished; admin/board sees all)
@@ -39,5 +40,8 @@ router.put('/:id', authenticateToken, verifyRole('admin', 'board'), updateCompet
 
 // Delete competition (admin only)
 router.delete('/:id', authenticateToken, verifyRole('admin'), deleteCompetition);
+
+// Mount competition announcements routes
+router.use('/:competitionId/announcements', competitionAnnouncementsRouter);
 
 module.exports = router;

--- a/server/services/competitionAnnouncementBroadcast.js
+++ b/server/services/competitionAnnouncementBroadcast.js
@@ -1,0 +1,105 @@
+const { Team, TeamMember, User, Competition } = require('../models');
+
+/**
+ * Get targeted competitor emails for an announcement
+ * @param {Object} announcement - CompetitionAnnouncement object
+ * @returns {Promise<string[]>} Array of unique email addresses
+ */
+async function getCompetitorEmails(announcement) {
+  try {
+    // 1. Specific competitor
+    if (announcement.target_type === 'competitor' && announcement.target_user_id) {
+      const user = await User.findByPk(announcement.target_user_id, { attributes: ['email'] });
+      return user && user.email ? [user.email.trim()] : [];
+    }
+
+    let teamIds = [];
+    
+    // 2. Specific team
+    if (announcement.target_type === 'team' && announcement.target_team_id) {
+      teamIds = [announcement.target_team_id];
+    } else {
+      // 3. All competitors in competition
+      const teams = await Team.findAll({
+        where: { competition_id: announcement.competition_id },
+        attributes: ['team_id']
+      });
+
+      if (teams.length === 0) {
+        console.log(`No teams found for competition ${announcement.competition_id}`);
+        return [];
+      }
+      teamIds = teams.map(team => team.team_id);
+    }
+
+    // Find all team members and their associated users
+    const teamMembers = await TeamMember.findAll({
+      where: { team_id: teamIds },
+      attributes: ['user_id'],
+      include: [{
+        model: User,
+        attributes: ['email'],
+        required: true
+      }]
+    });
+
+    // Extract unique emails
+    const emails = [
+      ...new Set(
+        teamMembers
+          .map(tm => (tm.User?.email || '').trim())
+          .filter(Boolean)
+      )
+    ];
+
+    console.log(`Found ${emails.length} unique emails for announcement ${announcement.announcement_id}`);
+    return emails;
+  } catch (error) {
+    console.error('Error fetching competitor emails:', error);
+    throw error;
+  }
+}
+
+/**
+ * Broadcast competition announcement emails to targeted competitors
+ * @param {Object} announcement - CompetitionAnnouncement object
+ * @param {Object} competition - Competition object
+ */
+async function broadcastCompetitionAnnouncementEmails(announcement, competition) {
+  try {
+    const emails = await getCompetitorEmails(announcement);
+
+    if (emails.length === 0) {
+      console.log(`Competition announcement: no recipients for announcement ${announcement.announcement_id}`);
+      return;
+    }
+
+    const { sendEmail } = await import('../utils/email.mjs');
+    const { buildCompetitionAnnouncementEmail } = await import('../utils/competitionAnnouncementEmail.mjs');
+
+    const { subject, text, html } = buildCompetitionAnnouncementEmail(announcement, competition, {
+      frontendUrl: process.env.FRONTEND_URL
+    });
+
+    // Send emails to each recipient individually for reliability
+    for (const to of emails) {
+      await sendEmail({
+        to,
+        subject,
+        text,
+        html,
+        fromName: 'MSP MIU Competition Announcements'
+      });
+    }
+
+    console.log(`Competition announcement emails sent to ${emails.length} recipient(s) for competition ${announcement.competition_id}`);
+  } catch (error) {
+    console.error('Error broadcasting competition announcement emails:', error);
+    throw error;
+  }
+}
+
+module.exports = {
+  getCompetitorEmails,
+  broadcastCompetitionAnnouncementEmails
+};

--- a/server/utils/competitionAnnouncementEmail.mjs
+++ b/server/utils/competitionAnnouncementEmail.mjs
@@ -1,0 +1,158 @@
+/**
+ * Build competition announcement email content
+ * @param {Object} announcement - CompetitionAnnouncement object
+ * @param {Object} competition - Competition object
+ * @param {Object} options - Configuration options
+ * @returns {Object} Email object with subject, text, and html
+ */
+export function buildCompetitionAnnouncementEmail(announcement, competition, options = {}) {
+  const { frontendUrl = 'https://msp-miu.com' } = options;
+  
+  const competitionLink = `${frontendUrl}/competitions/${announcement.competition_id}`;
+  
+  const subject = `${competition.title} - ${announcement.title}`;
+  
+  const text = `
+Hi Competitor,
+
+You have received a new announcement for the competition: ${competition.title}
+
+Title: ${announcement.title}
+
+Message:
+${announcement.message}
+
+View the competition: ${competitionLink}
+
+---
+This is an automated message from MSP MIU Competition Management System.
+  `.trim();
+  
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      color: #333;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+      background-color: #f9f9f9;
+      border: 1px solid #ddd;
+      border-radius: 5px;
+    }
+    .header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 20px;
+      border-radius: 5px 5px 0 0;
+      text-align: center;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+    .content {
+      padding: 20px;
+      background-color: white;
+    }
+    .competition-title {
+      color: #667eea;
+      font-size: 18px;
+      font-weight: bold;
+      margin-bottom: 10px;
+    }
+    .announcement-title {
+      font-size: 16px;
+      font-weight: bold;
+      color: #333;
+      margin-top: 15px;
+      margin-bottom: 10px;
+    }
+    .announcement-message {
+      background-color: #f5f5f5;
+      padding: 15px;
+      border-left: 4px solid #667eea;
+      margin: 15px 0;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+    .button {
+      display: inline-block;
+      background-color: #667eea;
+      color: white;
+      padding: 12px 30px;
+      text-decoration: none;
+      border-radius: 5px;
+      margin-top: 15px;
+      font-weight: bold;
+    }
+    .button:hover {
+      background-color: #764ba2;
+    }
+    .footer {
+      margin-top: 20px;
+      padding-top: 20px;
+      border-top: 1px solid #ddd;
+      font-size: 12px;
+      color: #666;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>📢 New Competition Announcement</h1>
+    </div>
+    <div class="content">
+      <p>Hi Competitor,</p>
+      <p>You have received a new announcement for the competition:</p>
+      
+      <div class="competition-title">${escapeHtml(competition.title)}</div>
+      
+      <div class="announcement-title">${escapeHtml(announcement.title)}</div>
+      
+      <div class="announcement-message">${escapeHtml(announcement.message)}</div>
+      
+      <a href="${competitionLink}" class="button">View Competition</a>
+      
+      <div class="footer">
+        <p>This is an automated message from MSP MIU Competition Management System.</p>
+        <p>Please do not reply to this email.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+  `.trim();
+  
+  return {
+    subject,
+    text,
+    html
+  };
+}
+
+/**
+ * Escape HTML special characters
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return String(text).replace(/[&<>"']/g, m => map[m]);
+}


### PR DESCRIPTION
- Implemented API endpoints for managing competition announcements including create, read, update, delete, and resend emails.
- Added frontend components for creating and displaying announcements in the admin panel.
- Enhanced styling for select options in CSS.
- Updated database models and associations for competition announcements.
- Created email templates for announcement notifications.
- Added middleware for role-based access control on announcement routes.
