### PR TITLE
feat: add board account activation email functionality

### DIFF
--- a/client/src/pages/Admin/BoardAdminTab.jsx
+++ b/client/src/pages/Admin/BoardAdminTab.jsx
@@ -49,6 +49,7 @@ export default function BoardAdminTab({ onAlert }) {
   const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [sendingId, setSendingId] = useState(null);
 
   useEffect(() => {
     (async () => {
@@ -203,6 +204,33 @@ export default function BoardAdminTab({ onAlert }) {
     }
   };
 
+  const sendActivationMail = async (row) => {
+    if (!row?.email) {
+      onAlert?.({ type: 'error', message: 'This board member has no email address.' });
+      return;
+    }
+    if (
+      !window.confirm(
+        `Send board account activation email to ${row.full_name} (${row.email})?`
+      )
+    ) {
+      return;
+    }
+    try {
+      setSendingId(row.board_id);
+      const result = await ApiService.sendBoardActivationEmail(row.board_id);
+      onAlert?.({
+        type: 'success',
+        message: result.message || `Board account activation email sent to ${row.email}`
+      });
+      await load();
+    } catch (err) {
+      onAlert?.({ type: 'error', message: err.message || 'Failed to send email' });
+    } finally {
+      setSendingId(null);
+    }
+  };
+
   return (
     <div className="AdminPanel__section">
       <div className="AdminPanel__sectionHeader">
@@ -227,31 +255,56 @@ export default function BoardAdminTab({ onAlert }) {
                 <th>Position</th>
                 <th>Dept</th>
                 <th>Faculty</th>
+                <th>Account</th>
                 <th>Visible</th>
                 <th>Order</th>
                 <th>Actions</th>
               </tr>
             </thead>
             <tbody>
-              {items.map((row) => (
-                <tr key={row.board_id}>
-                  <td style={{ fontWeight: 600 }}>
-                    {row.full_name}
-                    {isAll && (row.season || row.season_id) && (
-                      <> {' '}<SeasonBadge season={row.season} /></>
-                    )}
-                  </td>
-                  <td>{row.position}</td>
-                  <td>{row.department?.name || row.department_id || '—'}</td>
-                  <td>{row.faculty || '—'}</td>
-                  <td>{row.is_visible === false ? 'Hidden' : 'Yes'}</td>
-                  <td>{row.sort_order}</td>
-                  <td>
-                    <button type="button" className="AdminPanel__actionBtn AdminPanel__actionBtn--edit" onClick={() => openEdit(row)}>Edit</button>
-                    <button type="button" className="AdminPanel__actionBtn AdminPanel__actionBtn--delete" onClick={() => remove(row)}>Delete</button>
-                  </td>
-                </tr>
-              ))}
+              {items.map((row) => {
+                const hasAccount = Boolean(row.has_active_account);
+                return (
+                  <tr key={row.board_id}>
+                    <td style={{ fontWeight: 600 }}>
+                      {row.full_name}
+                      {isAll && (row.season || row.season_id) && (
+                        <> {' '}<SeasonBadge season={row.season} /></>
+                      )}
+                    </td>
+                    <td>{row.position}</td>
+                    <td>{row.department?.name || row.department_id || '—'}</td>
+                    <td>{row.faculty || '—'}</td>
+                    <td>
+                      <span
+                        className={`AdminPanel__badge AdminPanel__badge--${
+                          hasAccount ? 'active' : 'pending'
+                        }`}
+                      >
+                        {hasAccount ? 'Active' : 'No account'}
+                      </span>
+                    </td>
+                    <td>{row.is_visible === false ? 'Hidden' : 'Yes'}</td>
+                    <td>{row.sort_order}</td>
+                    <td>
+                      {!hasAccount && (
+                        <button
+                          type="button"
+                          className="AdminPanel__actionBtn AdminPanel__actionBtn--approve"
+                          disabled={sendingId === row.board_id}
+                          onClick={() => sendActivationMail(row)}
+                        >
+                          {sendingId === row.board_id
+                            ? 'Sending…'
+                            : 'Send board account activation email'}
+                        </button>
+                      )}
+                      <button type="button" className="AdminPanel__actionBtn AdminPanel__actionBtn--edit" onClick={() => openEdit(row)}>Edit</button>
+                      <button type="button" className="AdminPanel__actionBtn AdminPanel__actionBtn--delete" onClick={() => remove(row)}>Delete</button>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -716,6 +716,20 @@ class ApiService {
     return result;
   }
 
+  /** Send a board account activation email to a single board member. */
+  static async sendBoardActivationEmail(id) {
+    const response = await fetch(
+      `${API_BASE_URL}/board/${id}/send-activation-email`,
+      {
+        method: 'POST',
+        headers: this.getHeaders(true),
+      }
+    );
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || 'Failed to send board activation email');
+    return result;
+  }
+
   static async getMyBoardMembership() {
     const response = await fetch(`${API_BASE_URL}/board/me`, {
       method: 'GET',

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1292,6 +1292,24 @@ paths:
       responses:
         '200':
           description: Deleted
+  '/board/{id}/send-activation-email':
+    post:
+      summary: 'Create/submit /board/{id}/send-activation-email'
+      responses:
+        '200':
+          description: Success
+      tags:
+        - Board
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        -
+          bearerAuth: []
   /board/me:
     get:
       summary: 'Get /board/me'

--- a/server/controllers/board.js
+++ b/server/controllers/board.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const { Board, Department, Season } = require('../models');
+const { Op } = require('sequelize');
+const { Board, Department, Season, User } = require('../models');
 const { parsePagination, paginationMeta } = require('../utils/pagination');
 const {
   resolveSeasonFilter,
@@ -8,8 +9,59 @@ const {
   getDefaultSeasonId
 } = require('../utils/seasonFilter');
 const { r2, PutObjectCommand } = require('../config/cloud');
+const { sendBoardActivationEmailForMember } = require('../utils/boardActivationEmail');
 
 const POSITION_VALUES = ['President', 'Vice President', 'Head', 'Co-Head', 'Founder'];
+
+function hasActiveAccount(user) {
+  return Boolean(user && (user.is_active || user.password_hash));
+}
+
+async function attachAccountStatus(boardMembers) {
+  const emails = [
+    ...new Set(
+      boardMembers
+        .map((m) => (m.email ? String(m.email).trim() : null))
+        .filter(Boolean)
+    )
+  ];
+  const userIds = [
+    ...new Set(
+      boardMembers
+        .map((m) => (m.user_id != null && m.user_id !== '' ? Number(m.user_id) : null))
+        .filter((id) => Number.isFinite(id) && id > 0)
+    )
+  ];
+
+  const orClauses = [];
+  if (emails.length) orClauses.push({ email: { [Op.in]: emails } });
+  if (userIds.length) orClauses.push({ user_id: { [Op.in]: userIds } });
+
+  const users = orClauses.length
+    ? await User.findAll({
+        where: { [Op.or]: orClauses },
+        attributes: ['user_id', 'email', 'is_active', 'password_hash']
+      })
+    : [];
+
+  const userById = new Map(users.map((u) => [Number(u.user_id), u]));
+  const userByEmail = new Map(
+    users
+      .filter((u) => u.email)
+      .map((u) => [String(u.email).trim().toLowerCase(), u])
+  );
+
+  return boardMembers.map((member) => {
+    const json = typeof member.toJSON === 'function' ? member.toJSON() : { ...member };
+    const linked = json.user_id != null ? userById.get(Number(json.user_id)) : null;
+    const emailKey = json.email ? String(json.email).trim().toLowerCase() : null;
+    const byEmail = emailKey ? userByEmail.get(emailKey) : null;
+    return {
+      ...json,
+      has_active_account: hasActiveAccount(linked) || hasActiveAccount(byEmail)
+    };
+  });
+}
 
 async function findBoardMembershipForUser(userId) {
   const members = await Board.findAll({
@@ -80,10 +132,13 @@ const getBoard = async (req, res) => {
       distinct: true
     });
 
+    // Account status is admin-only (includeHidden requires auth)
+    const data = includeHidden ? await attachAccountStatus(rows) : rows;
+
     res.json({
       success: true,
-      data: rows,
-      count: rows.length,
+      data,
+      count: data.length,
       pagination: paginationMeta({ page, limit, total })
     });
   } catch (err) {
@@ -164,7 +219,6 @@ const member = await Board.create({
     if (member.email) {
       try {
         const { sendEmail } = await import('../utils/email.mjs');
-        const { sendBoardActivationEmailForMember } = require('../utils/boardActivationEmail');
         const result = await sendBoardActivationEmailForMember(member, sendEmail);
         activationEmail = result;
       } catch (emailErr) {
@@ -368,11 +422,56 @@ const updateMyBoardPhoto = async (req, res) => {
   }
 };
 
+/**
+ * Send a board account activation email to a single board member.
+ */
+const sendBoardActivationEmail = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const member = await Board.findByPk(id);
+    if (!member) {
+      return res.status(404).json({ success: false, error: 'Board member not found' });
+    }
+
+    const { sendEmail } = await import('../utils/email.mjs');
+    const result = await sendBoardActivationEmailForMember(member, sendEmail);
+
+    if (result.skipped) {
+      return res.status(400).json({
+        success: false,
+        error: result.reason || 'Board member already has an active account',
+        data: result
+      });
+    }
+
+    if (!result.success) {
+      return res.status(500).json({
+        success: false,
+        error: result.error || 'Failed to send activation email',
+        data: result
+      });
+    }
+
+    res.json({
+      success: true,
+      message: `Board account activation email sent to ${result.email}`,
+      data: result
+    });
+  } catch (error) {
+    console.error('Error sending board activation email:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message || 'Failed to send board activation email'
+    });
+  }
+};
+
 module.exports = {
   getBoard,
   createBoardMember,
   updateBoardMember,
   deleteBoardMember,
   getMyBoardMembership,
-  updateMyBoardPhoto
+  updateMyBoardPhoto,
+  sendBoardActivationEmail
 };

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -7,7 +7,8 @@ const {
   updateBoardMember,
   deleteBoardMember,
   getMyBoardMembership,
-  updateMyBoardPhoto
+  updateMyBoardPhoto,
+  sendBoardActivationEmail
 } = require('../controllers/board');
 const { authenticateToken, verifyRole } = require('../middlewares/auth');
 
@@ -32,6 +33,12 @@ router.put(
   updateMyBoardPhoto
 );
 router.post('/', authenticateToken, verifyRole('admin', 'board'), createBoardMember);
+router.post(
+  '/:id/send-activation-email',
+  authenticateToken,
+  verifyRole('admin', 'board'),
+  sendBoardActivationEmail
+);
 router.put('/:id', authenticateToken, verifyRole('admin', 'board'), updateBoardMember);
 router.delete('/:id', authenticateToken, verifyRole('admin', 'board'), deleteBoardMember);
 

--- a/server/utils/boardActivationEmail.js
+++ b/server/utils/boardActivationEmail.js
@@ -42,6 +42,25 @@ async function sendBoardActivationEmailForMember(boardMember, sendEmail) {
     };
   }
 
+  if (boardMember.user_id) {
+    const linkedUser = await User.findByPk(boardMember.user_id, {
+      attributes: ['user_id', 'email', 'is_active', 'password_hash']
+    });
+    if (linkedUser && (linkedUser.is_active || linkedUser.password_hash)) {
+      return {
+        success: false,
+        skipped: true,
+        boardId: boardMember.board_id,
+        name: boardMemberName,
+        position,
+        email,
+        reason: linkedUser.is_active
+          ? 'Linked account is already active'
+          : 'Linked account already has a password'
+      };
+    }
+  }
+
   const tokenResult = generateToken({
     email,
     type: 'board_activation',


### PR DESCRIPTION
- Implemented a new feature to send activation emails to board members from the Admin panel.
- Added a confirmation prompt before sending the email to ensure user intent.
- Enhanced the API service to handle sending activation emails and return appropriate responses.
- Updated the board management UI to display account status and allow email sending for members without active accounts.
- Integrated account status checks to prevent sending emails to members with existing active accounts.