### PR TITLE
feat: update file upload handling for board photos

### DIFF
--- a/client/src/pages/Admin/BoardAdminTab.jsx
+++ b/client/src/pages/Admin/BoardAdminTab.jsx
@@ -132,7 +132,7 @@ export default function BoardAdminTab({ onAlert }) {
     if (!file) return;
     try {
       setUploading(true);
-      const result = await ApiService.uploadFile(file, 'images');
+      const result = await ApiService.uploadFile(file, 'board_photos');
       setForm((f) => ({ ...f, photo_url: result.url || '' }));
       onAlert?.({ type: 'success', message: 'Photo uploaded.' });
     } catch (err) {

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1757,7 +1757,7 @@ class ApiService {
   /**
    * Upload a file to R2 storage
    * @param {File} file - The file to upload
-   * @param {string} type - The upload type (assets, codes, events, images, mobile, slides, courses)
+   * @param {string} type - The upload type (assets, board_photos, codes, events, images, mobile, slides, courses, …)
    * @param {Record<string, string|number>} [query] - Optional query (course_id, lesson_id, kind)
    * @returns {Promise<{success: boolean, url: string, key: string}>}
    */

--- a/server/controllers/board.js
+++ b/server/controllers/board.js
@@ -421,7 +421,7 @@ const updateMyBoardPhoto = async (req, res) => {
 
       const ext = path.extname(photoFile.originalname) || '.png';
       const unique = `${Date.now()}_${Math.random().toString(36).substring(2)}${ext}`;
-      const key = `Images/board_${userId}_${unique}`;
+      const key = `Board_Photos/board_${userId}_${unique}`;
 
       await r2.send(
         new PutObjectCommand({

--- a/server/controllers/cloud.js
+++ b/server/controllers/cloud.js
@@ -3,10 +3,28 @@ const { ListObjectsV2Command, DeleteObjectCommand } = require('@aws-sdk/client-s
 const path = require('path');
 const { Op } = require('sequelize');
 const Event = require('../models/Event');
+const Board = require('../models/Board');
 const { parsePagination, paginationMeta, paginateArray } = require('../utils/pagination');
+
+/** Extract R2 object key from a public URL (or return the path if already a key). */
+function r2KeyFromPublicUrl(urlOrKey) {
+  if (!urlOrKey || typeof urlOrKey !== 'string') return null;
+  const trimmed = urlOrKey.trim();
+  if (!trimmed) return null;
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/^\/+/, '');
+  }
+  try {
+    const { pathname } = new URL(trimmed);
+    return decodeURIComponent(pathname.replace(/^\/+/, ''));
+  } catch {
+    return null;
+  }
+}
 
 const CLOUD_DIRECTORY_PREFIXES = [
   'Assets/',
+  'Board_Photos/',
   'Codes/',
   'Courses/',
   'Events_Thumbnails/',
@@ -154,7 +172,7 @@ async function attachEventLinks(assets, type) {
   });
 }
 
-// Get all images from cloud storage
+// Get gallery dome images only (excludes Meet the Board portraits)
 const getImages = async (req, res) => {
   try {
     const bucket = process.env.R2_BUCKET;
@@ -165,16 +183,30 @@ const getImages = async (req, res) => {
       Prefix: prefix
     });
 
-    const response = await r2.send(command);
+    const [response, boardRows] = await Promise.all([
+      r2.send(command),
+      Board.findAll({
+        attributes: ['photo_url'],
+        where: { photo_url: { [Op.ne]: null } },
+        raw: true
+      })
+    ]);
+
+    const boardPhotoKeys = new Set(
+      boardRows
+        .map((row) => r2KeyFromPublicUrl(row.photo_url))
+        .filter((key) => key && key.startsWith(prefix))
+    );
     
-    // Filter out directories (objects ending with /) and get only image files
+    // Filter out directories, non-images, and Meet the Board portraits
     const imageFiles = (response.Contents || [])
       .filter(obj => {
-        // Exclude directories and ensure it's an image file
         const key = obj.Key;
         const isDirectory = key.endsWith('/');
         const isImage = /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(key);
-        return !isDirectory && isImage;
+        const isLegacyBoardUpload = /^Images\/board_/i.test(key);
+        const isLinkedBoardPhoto = boardPhotoKeys.has(key);
+        return !isDirectory && isImage && !isLegacyBoardUpload && !isLinkedBoardPhoto;
       })
       .map(obj => {
         // Return the full URL to the image using secure URL construction

--- a/server/middlewares/multer.js
+++ b/server/middlewares/multer.js
@@ -39,6 +39,7 @@ const apkUpload = multer({
 // Map type → directory (flat prefixes; courses uses hierarchical keys below)
 const directoryMap = {
   assets: "Assets/",
+  board_photos: "Board_Photos/",
   codes: "Codes/",
   events: "Events_Thumbnails/",
   images: "Images/",


### PR DESCRIPTION
- Changed the upload type from 'images' to 'board_photos' in the file upload process.
- Updated API documentation to reflect the new upload type for board photos.
- Modified server-side logic to store uploaded board photos in the 'Board_Photos' directory.
- Enhanced cloud storage retrieval to filter out legacy board uploads and ensure only relevant images are fetched.