### PR TITLE
feat: add email notification feature for announcements

### DIFF
--- a/client/src/pages/Admin/AdminPanel.jsx
+++ b/client/src/pages/Admin/AdminPanel.jsx
@@ -168,7 +168,7 @@ const AdminPanel = () => {
     const [showAnnouncementModal, setShowAnnouncementModal] = useState(false);
     const [editingAnnouncement, setEditingAnnouncement] = useState(null);
     const [announcementForm, setAnnouncementForm] = useState({
-        title: '', description: '', department: '', announcement_date: '', priority: false
+        title: '', description: '', department: '', announcement_date: '', priority: false, send_email: false
     });
 
     // Suggestions & Feedback state
@@ -481,14 +481,16 @@ const AdminPanel = () => {
                 description: (announcement.description || '').slice(0, ANNOUNCEMENT_DESC_MAX),
                 department: announcement.department || '',
                 announcement_date: announcement.announcement_date ? announcement.announcement_date.split('T')[0] : '',
-                priority: !!announcement.priority
+                priority: !!announcement.priority,
+                send_email: !!announcement.send_email
             });
         } else {
             setEditingAnnouncement(null);
             setAnnouncementForm({
                 title: '', description: '', department: '',
                 announcement_date: new Date().toISOString().split('T')[0],
-                priority: false
+                priority: false,
+                send_email: false
             });
         }
         setShowAnnouncementModal(true);
@@ -501,11 +503,17 @@ const AdminPanel = () => {
                 payload.season_id = selectedSeasonId;
             }
             if (editingAnnouncement) {
-                await ApiService.updateAnnouncement(editingAnnouncement.announcement_id, payload);
+                const { send_email, ...updatePayload } = payload;
+                await ApiService.updateAnnouncement(editingAnnouncement.announcement_id, updatePayload);
                 setAlert({ type: 'success', message: 'Announcement updated!' });
             } else {
                 await ApiService.createAnnouncement(payload);
-                setAlert({ type: 'success', message: 'Announcement created!' });
+                setAlert({
+                    type: 'success',
+                    message: payload.send_email
+                        ? 'Announcement created and emailed to members!'
+                        : 'Announcement created (website only)!'
+                });
             }
             setShowAnnouncementModal(false);
             fetchAnnouncementsAdmin(false);
@@ -1073,6 +1081,7 @@ const AdminPanel = () => {
                                                 <th>Department</th>
                                                 <th>Date</th>
                                                 <th>Priority</th>
+                                                <th>Email</th>
                                                 <th>Actions</th>
                                             </tr>
                                         </thead>
@@ -1090,6 +1099,11 @@ const AdminPanel = () => {
                                                     <td>
                                                         <span className={`AdminPanel__badge AdminPanel__badge--${a.priority ? 'active' : 'completed'}`}>
                                                             {a.priority ? 'High' : 'Normal'}
+                                                        </span>
+                                                    </td>
+                                                    <td>
+                                                        <span className={`AdminPanel__badge AdminPanel__badge--${a.send_email ? 'active' : 'completed'}`}>
+                                                            {a.send_email ? 'Emailed' : 'Website only'}
                                                         </span>
                                                     </td>
                                                     <td>
@@ -1123,7 +1137,9 @@ const AdminPanel = () => {
                                             <h3 className="AdminPanel__modalTitle">{editingAnnouncement ? 'Edit Announcement' : 'Add Announcement'}</h3>
                                             {!editingAnnouncement && (
                                                 <p className="AdminPanel__emailNote" role="note">
-                                                    Note: creating this announcement will send an email about it to all members.
+                                                    {announcementForm.send_email
+                                                        ? 'This announcement will appear on the website and an email will be sent to all members.'
+                                                        : 'This announcement will appear on the website only. Check “Send email” to also notify members by mail.'}
                                                 </p>
                                             )}
                                             <div className="AdminPanel__formGroup">
@@ -1167,6 +1183,19 @@ const AdminPanel = () => {
                                                     {' '}Priority
                                                 </label>
                                             </div>
+                                            {!editingAnnouncement && (
+                                                <div className="AdminPanel__formGroup">
+                                                    <label htmlFor="announcement-send-email">
+                                                        <input
+                                                            id="announcement-send-email"
+                                                            type="checkbox"
+                                                            checked={announcementForm.send_email}
+                                                            onChange={e => setAnnouncementForm({ ...announcementForm, send_email: e.target.checked })}
+                                                        />
+                                                        {' '}Send email notification to all members
+                                                    </label>
+                                                </div>
+                                            )}
                                             <div className="AdminPanel__modalActions">
                                                 <button className="AdminPanel__modalBtn AdminPanel__modalBtn--secondary" onClick={() => setShowAnnouncementModal(false)}>Cancel</button>
                                                 <button className="AdminPanel__modalBtn AdminPanel__modalBtn--primary" onClick={saveAnnouncement}>{editingAnnouncement ? 'Save' : 'Create'}</button>

--- a/client/src/pages/Home/FeedSection/FeedSection.css
+++ b/client/src/pages/Home/FeedSection/FeedSection.css
@@ -270,6 +270,17 @@
     cursor: pointer;
 }
 
+.Feed__formHint {
+    margin: 0;
+    padding: 10px 14px;
+    background: rgba(3, 169, 244, 0.12);
+    border: 1px solid rgba(3, 169, 244, 0.28);
+    border-radius: 10px;
+    color: #8EC2F0;
+    font-size: 0.85rem;
+    line-height: 1.45;
+}
+
 .Feed__formError {
     padding: 12px 16px;
     background: rgba(255, 87, 87, .15);

--- a/client/src/pages/Home/FeedSection/FeedSection.jsx
+++ b/client/src/pages/Home/FeedSection/FeedSection.jsx
@@ -22,7 +22,8 @@ const FeedSection = memo(() => {
     description: '',
     department: '',
     announcement_date: '',
-    priority: false
+    priority: false,
+    send_email: false
   });
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState(null);
@@ -118,7 +119,8 @@ const FeedSection = memo(() => {
         description: '',
         department: '',
         announcement_date: '',
-        priority: false
+        priority: false,
+        send_email: false
       });
       // Refresh announcements list
       setPage(1);
@@ -138,7 +140,8 @@ const FeedSection = memo(() => {
       description: '',
       department: '',
       announcement_date: '',
-      priority: false
+      priority: false,
+      send_email: false
     });
     setSubmitError(null);
   };
@@ -291,6 +294,24 @@ const FeedSection = memo(() => {
                       <span>Priority Announcement</span>
                     </label>
                   </div>
+
+                  <div className="Feed__formGroup Feed__formGroup--checkbox">
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="send_email"
+                        checked={formData.send_email}
+                        onChange={handleInputChange}
+                      />
+                      <span>Send email notification to all members</span>
+                    </label>
+                  </div>
+
+                  {formData.send_email && (
+                    <p className="Feed__formHint" role="note">
+                      An email about this announcement will be sent to all members.
+                    </p>
+                  )}
 
                   {submitError && (
                     <div className="Feed__formError">{submitError}</div>

--- a/server/controllers/announcements.js
+++ b/server/controllers/announcements.js
@@ -137,7 +137,7 @@ const getAnnouncementById = async (req, res) => {
  */
 const addAnnouncement = async (req, res) => {
   try {
-    const { title, description, department, announcement_date, priority } = req.body;
+    const { title, description, department, announcement_date, priority, send_email } = req.body;
     const userId = req.user.user_id;
 
     // Validation
@@ -157,12 +157,15 @@ const addAnnouncement = async (req, res) => {
       });
     }
 
+    const shouldSendEmail = send_email === true || send_email === 'true' || send_email === 1;
+
     const announcement = await Announcement.create({
       title,
       description,
       department,
       announcement_date: announcement_date,
       priority: priority === true || priority === 'true' || priority === 1,
+      send_email: shouldSendEmail,
       created_by: userId,
       is_active: true,
       season_id: await resolveSeasonIdForWrite(req.body, req.query)
@@ -176,11 +179,15 @@ const addAnnouncement = async (req, res) => {
       }]
     });
 
-    await broadcastNewAnnouncementEmails(createdAnnouncement);
+    if (createdAnnouncement.send_email) {
+      await broadcastNewAnnouncementEmails(createdAnnouncement);
+    }
 
     return res.status(201).json({
       success: true,
-      message: 'Announcement created successfully and emails sent',
+      message: createdAnnouncement.send_email
+        ? 'Announcement created successfully and emails sent'
+        : 'Announcement created successfully (website only)',
       data: createdAnnouncement
     });
   } catch (error) {

--- a/server/controllers/emailTemplates.js
+++ b/server/controllers/emailTemplates.js
@@ -140,7 +140,10 @@ const SAMPLE_VARS = {
     titleHtml: 'Sample Announcement',
     descriptionHtml: 'This is a sample announcement body.',
     preheader: 'This is a sample announcement body.',
-    testBannerHtml: ''
+    testBannerHtml: '',
+    metaHtml: '<p style="margin:14px 0 0;"><span style="display:inline-block;padding:4px 10px;background:#eaf2ff;color:#0d7bd8;border-radius:999px;font-size:12px;font-weight:600;">Technical</span></p>',
+    departmentLine: 'Department: Technical\n',
+    dateLine: 'Date: 15 August 2026\n\n'
   },
   android_app_update: {
     title: 'Android app update 1.0.1',

--- a/server/models/Announcement.js
+++ b/server/models/Announcement.js
@@ -40,6 +40,11 @@ const Announcement = sequelize.define('Announcement', {
     defaultValue: false,
     allowNull: false
   },
+  send_email: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: false,
+    allowNull: false
+  },
   created_by: {
     type: DataTypes.INTEGER,
     allowNull: false,

--- a/server/scripts/patchCmsSchema.js
+++ b/server/scripts/patchCmsSchema.js
@@ -66,6 +66,13 @@ async function addColumn(table, column, ddl) {
     await addColumn('competitions', 'max_teams', 'max_teams INT NULL');
     await addColumn('competitions', 'registration_deadline', 'registration_deadline DATETIME NULL');
 
+    // site announcements: optional email broadcast
+    await addColumn(
+      'announcements',
+      'send_email',
+      'send_email TINYINT(1) NOT NULL DEFAULT 0'
+    );
+
     // users.score nulls that break full alter sync
     if (await columnExists('users', 'score')) {
       await sequelize.query('UPDATE users SET score = 0 WHERE score IS NULL');

--- a/server/utils/announcementEmail.mjs
+++ b/server/utils/announcementEmail.mjs
@@ -20,17 +20,38 @@ export async function buildAnnouncementEmail(announcement, options = {}) {
 
   const title = announcement.title || 'Announcement';
   const description = announcement.description || '';
+  const department = (announcement.department || '').trim();
+  const rawDate = announcement.announcement_date || '';
 
   const titleHtml = escapeHtml(title);
   const descriptionHtml = escapeHtml(description).replace(/\n/g, '<br/>');
   const preheader = escapeHtml(plainPreview(description, 140) || title);
 
+  const dateLabel = formatAnnouncementDate(rawDate);
+  const metaParts = [];
+  if (department) {
+    metaParts.push(
+      `<span style="display:inline-block;padding:4px 10px;background:#eaf2ff;color:#0d7bd8;border-radius:999px;font-size:12px;font-weight:600;">${escapeHtml(department)}</span>`
+    );
+  }
+  if (dateLabel) {
+    metaParts.push(
+      `<span style="display:inline-block;font-size:13px;color:#666666;">${escapeHtml(dateLabel)}</span>`
+    );
+  }
+  const metaHtml = metaParts.length
+    ? `<p style="margin:14px 0 0;display:flex;flex-wrap:wrap;gap:10px;align-items:center;">${metaParts.join('')}</p>`
+    : '';
+
+  const departmentLine = department ? `Department: ${department}\n` : '';
+  const dateLine = dateLabel ? `Date: ${dateLabel}\n\n` : department ? '\n' : '';
+
   let testBannerHtml = '';
   if (testMode && announcementId != null) {
     testBannerHtml = `<tr>
-  <td style="padding:16px 26px 0;font-family:Inter,system-ui,sans-serif;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:rgba(255,191,0,0.12);border:1px solid rgba(255,191,0,0.45);border-radius:12px;">
-      <tr><td style="padding:12px 16px;font-size:13px;color:#ffd666;line-height:1.5;">
+  <td style="padding:16px 36px 0;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#fff8e6;border:1px solid #f0d58a;border-radius:6px;">
+      <tr><td style="padding:12px 16px;font-size:13px;color:#8a6d1d;line-height:1.5;">
         <strong>Test email</strong> · announcement_id=${escapeHtml(String(announcementId))}
       </td></tr>
     </table>
@@ -38,8 +59,8 @@ export async function buildAnnouncementEmail(announcement, options = {}) {
 </tr>`;
   } else if (testMode) {
     testBannerHtml = `<tr>
-  <td style="padding:16px 26px 0;font-family:Inter,system-ui,sans-serif;">
-    <p style="margin:0;padding:12px 16px;background:rgba(255,191,0,0.12);border:1px solid rgba(255,191,0,0.45);border-radius:12px;font-size:13px;color:#ffd666;"><strong>Test email</strong></p>
+  <td style="padding:16px 36px 0;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;">
+    <p style="margin:0;padding:12px 16px;background:#fff8e6;border:1px solid #f0d58a;border-radius:6px;font-size:13px;color:#8a6d1d;"><strong>Test email</strong></p>
   </td>
 </tr>`;
   }
@@ -51,7 +72,10 @@ export async function buildAnnouncementEmail(announcement, options = {}) {
     titleHtml,
     descriptionHtml,
     preheader,
-    testBannerHtml
+    testBannerHtml,
+    metaHtml,
+    departmentLine,
+    dateLine
   });
 
   const subject = testMode ? `[TEST] ${rendered.subject}` : rendered.subject;
@@ -60,6 +84,19 @@ export async function buildAnnouncementEmail(announcement, options = {}) {
     : rendered.text;
 
   return { subject, text, html: rendered.html };
+}
+
+function formatAnnouncementDate(value) {
+  if (!value) return '';
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    return String(value);
+  }
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  });
 }
 
 function plainPreview(text, maxLen) {

--- a/server/utils/emailTemplates/defaults.js
+++ b/server/utils/emailTemplates/defaults.js
@@ -365,7 +365,7 @@ This is an automated email, please do not reply.`,
     '{{title}}',
     `{{title}}
 
-{{description}}
+{{departmentLine}}{{dateLine}}{{description}}
 
 —
 MSP MIU · {{frontendUrl}}`,
@@ -374,41 +374,42 @@ MSP MIU · {{frontendUrl}}`,
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>{{title}}</title>
 </head>
-<body style="margin:0;padding:0;background:#091a2c;-webkit-text-size-adjust:100%;">
-  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#091a2c;opacity:0;">{{preheader}}</div>
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#091a2c;">
+<body style="margin:0;padding:0;background-color:#f4f4f4;-webkit-text-size-adjust:100%;font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;">
+  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#f4f4f4;opacity:0;">{{preheader}}</div>
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;background-color:#f4f4f4;">
     <tr>
-      <td align="center" style="padding:28px 16px;">
-        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#0e2744;border:1px solid #1e3a52;border-radius:18px;overflow:hidden;">
-          <tr><td style="height:4px;line-height:4px;font-size:0;background:#03A9F4;">&nbsp;</td></tr>
+      <td align="center" style="padding:24px 12px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;border-collapse:collapse;background-color:#ffffff;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);overflow:hidden;">
           <tr>
-            <td style="background:#031c35;padding:20px 26px 18px;border-bottom:1px solid rgba(255,255,255,0.08);">
-              <p style="margin:0;font-family:Inter,system-ui,sans-serif;font-size:20px;font-weight:700;letter-spacing:0.5px;line-height:1.2;">
-                <span style="color:#8EC2F0;">MSP</span><span style="color:#eaf2ff;"> · MIU</span>
-              </p>
-              <p style="margin:8px 0 0;font-family:Inter,system-ui,sans-serif;font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#5AA0E6;font-weight:600;">Announcement</p>
+            <td style="padding:28px 36px;background:linear-gradient(135deg,#031C35 0%,#0D3159 50%,#1D4F82 100%);">
+              <p style="margin:0;font-size:22px;font-weight:600;letter-spacing:0.3px;line-height:1.2;color:#ffffff;">MSP MIU</p>
+              <p style="margin:10px 0 0;font-size:11px;letter-spacing:0.16em;text-transform:uppercase;color:#8EC2F0;font-weight:600;">Announcement</p>
             </td>
           </tr>
           {{testBannerHtml}}
           <tr>
-            <td style="padding:22px 26px 8px;font-family:Inter,system-ui,sans-serif;">
-              <h1 style="margin:0;font-size:19px;font-weight:600;letter-spacing:0.4px;color:#ffffff;line-height:1.35;">{{titleHtml}}</h1>
+            <td style="padding:32px 36px 8px;">
+              <h1 style="margin:0;font-size:22px;font-weight:600;color:#031C35;line-height:1.35;">{{titleHtml}}</h1>
+              {{metaHtml}}
             </td>
           </tr>
           <tr>
-            <td style="padding:10px 26px 26px;font-family:Inter,system-ui,sans-serif;font-size:14px;line-height:1.55;color:#8EC2F0;">{{descriptionHtml}}</td>
-          </tr>
-          <tr>
-            <td style="padding:0 26px 28px;font-family:Inter,system-ui,sans-serif;" align="center">
-              <a href="{{frontendUrl}}" style="display:inline-block;padding:12px 26px;background:#03A9F4;color:#ffffff;text-decoration:none;border-radius:12px;font-weight:600;font-size:13px;letter-spacing:0.35px;">Visit MSP MIU</a>
+            <td style="padding:12px 36px 28px;">
+              <div style="padding:18px 20px;background-color:#eaf2ff;border-radius:6px;border-left:4px solid #03A9F4;font-size:15px;line-height:1.65;color:#333333;">{{descriptionHtml}}</div>
             </td>
           </tr>
           <tr>
-            <td style="padding:20px 26px 24px;border-top:1px solid rgba(255,255,255,0.08);font-family:Inter,system-ui,sans-serif;font-size:12px;line-height:1.55;color:#8a8a8a;text-align:center;">
-              <p style="margin:0 0 10px;"><a href="{{frontendUrl}}" style="color:#03A9F4;text-decoration:none;font-weight:600;">{{frontendUrl}}</a></p>
-              <p style="margin:0;color:#8a8a8a;">You receive these messages because you have an account with MSP MIU.</p>
+            <td style="padding:0 36px 32px;text-align:center;">
+              <a href="{{frontendUrl}}" style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#0d7bd8 0%,#03A9F4 100%);color:#ffffff;text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;box-shadow:0 4px 8px rgba(13,123,216,0.3);">View on MSP MIU</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 36px 22px;background-color:#f9f9f9;border-top:1px solid #eeeeee;font-size:13px;line-height:1.55;color:#666666;text-align:center;">
+              <p style="margin:0 0 8px;"><a href="{{frontendUrl}}" style="color:#0d7bd8;text-decoration:none;font-weight:600;">{{frontendUrl}}</a></p>
+              <p style="margin:0;">You receive these messages because you have an account with MSP MIU.</p>
             </td>
           </tr>
         </table>
@@ -417,7 +418,7 @@ MSP MIU · {{frontendUrl}}`,
   </table>
 </body>
 </html>`,
-    ['title', 'description', 'frontendUrl', 'titleHtml', 'descriptionHtml', 'preheader', 'testBannerHtml']
+    ['title', 'description', 'frontendUrl', 'titleHtml', 'descriptionHtml', 'preheader', 'testBannerHtml', 'metaHtml', 'departmentLine', 'dateLine']
   ),
 
   android_app_update: def(
@@ -511,22 +512,25 @@ This is an automated message from MSP MIU Competition Management System.`,
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">
-  <div style="max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9; border: 1px solid #ddd; border-radius: 5px;">
-    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 5px 5px 0 0; text-align: center;">
-      <h1 style="margin: 0; font-size: 24px;">📢 New Competition Announcement</h1>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; color: #333; line-height: 1.6;">
+  <div style="max-width: 600px; margin: 0 auto; padding: 24px 12px;">
+    <div style="background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
+    <div style="background: linear-gradient(135deg, #031C35 0%, #0D3159 50%, #1D4F82 100%); color: white; padding: 28px 36px;">
+      <p style="margin: 0; font-size: 22px; font-weight: 600; color: #ffffff;">MSP MIU</p>
+      <p style="margin: 10px 0 0; font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: #8EC2F0; font-weight: 600;">Competition Announcement</p>
     </div>
-    <div style="padding: 20px; background-color: white;">
-      <p>Hi Competitor,</p>
-      <p>You have received a new announcement for the competition:</p>
-      <div style="color: #667eea; font-size: 18px; font-weight: bold; margin-bottom: 10px;">{{competitionTitleHtml}}</div>
-      <div style="font-size: 16px; font-weight: bold; color: #333; margin-top: 15px; margin-bottom: 10px;">{{announcementTitleHtml}}</div>
-      <div style="background-color: #f5f5f5; padding: 15px; border-left: 4px solid #667eea; margin: 15px 0; white-space: pre-wrap; word-wrap: break-word;">{{announcementMessageHtml}}</div>
-      <a href="{{competitionLink}}" style="display: inline-block; background-color: #667eea; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; margin-top: 15px; font-weight: bold;">View Competition</a>
-      <div style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666; text-align: center;">
-        <p>This is an automated message from MSP MIU Competition Management System.</p>
-        <p>Please do not reply to this email.</p>
+    <div style="padding: 28px 36px; background-color: white;">
+      <p style="margin: 0 0 8px; font-size: 13px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: #0d7bd8;">{{competitionTitleHtml}}</p>
+      <h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 600; color: #031C35; line-height: 1.35;">{{announcementTitleHtml}}</h1>
+      <div style="background-color: #eaf2ff; padding: 18px 20px; border-left: 4px solid #03A9F4; border-radius: 6px; margin: 0 0 24px; white-space: pre-wrap; word-wrap: break-word; font-size: 15px; line-height: 1.65; color: #333333;">{{announcementMessageHtml}}</div>
+      <div style="text-align: center;">
+        <a href="{{competitionLink}}" style="display: inline-block; background: linear-gradient(135deg, #0d7bd8 0%, #03A9F4 100%); color: white; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px; box-shadow: 0 4px 8px rgba(13, 123, 216, 0.3);">View Competition</a>
       </div>
+      <div style="margin-top: 24px; padding-top: 18px; border-top: 1px solid #eeeeee; font-size: 13px; color: #666666; text-align: center;">
+        <p style="margin: 0 0 8px;">This is an automated message from MSP MIU Competition Management.</p>
+        <p style="margin: 0;">Please do not reply to this email.</p>
+      </div>
+    </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
- Introduced a new 'send_email' option in the announcement creation and editing forms to allow users to notify members via email.
- Updated the AdminPanel and FeedSection components to handle the new email notification functionality.
- Enhanced server-side logic to process the 'send_email' flag and send emails accordingly when announcements are created or updated.
- Modified email templates to include department and date information for better context in notifications.
- Added a new column in the database schema to store the 'send_email' preference for announcements.