### PR TITLE
feat: enhance announcement management with email and website options

### DIFF
--- a/client/src/pages/Admin/AdminPanel.css
+++ b/client/src/pages/Admin/AdminPanel.css
@@ -793,6 +793,13 @@ body.admin-panel-active .SiteLayout__main {
     gap: 14px;
 }
 
+.AdminPanel__headerActions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
 .AdminPanel__sectionTitle {
     margin: 0;
     font-size: 1.2rem;
@@ -823,6 +830,19 @@ body.admin-panel-active .SiteLayout__main {
     transform: translateY(-2px);
     box-shadow: 0 8px 24px -6px rgba(13, 123, 216, 0.45);
     filter: brightness(1.08);
+}
+
+.AdminPanel__addBtn--secondary {
+    background: transparent;
+    border: 1px solid rgba(142, 194, 240, 0.35);
+    color: #8EC2F0;
+}
+
+.AdminPanel__addBtn--secondary:hover {
+    background: rgba(3, 169, 244, 0.12);
+    border-color: rgba(3, 169, 244, 0.45);
+    box-shadow: none;
+    filter: none;
 }
 
 /* ── Table ── */

--- a/client/src/pages/Admin/AdminPanel.jsx
+++ b/client/src/pages/Admin/AdminPanel.jsx
@@ -33,8 +33,12 @@ import './AdminPanel.css';
 
 const LIST_LIMIT = 20;
 const NOTIFICATIONS_LIMIT = 50;
-const ANNOUNCEMENT_TITLE_MAX = 50;
-const ANNOUNCEMENT_DESC_MAX = 220;
+/** Short copy for website feed cards */
+const WEBSITE_ANNOUNCEMENT_TITLE_MAX = 50;
+const WEBSITE_ANNOUNCEMENT_DESC_MAX = 220;
+/** Longer copy allowed for email broadcasts */
+const EMAIL_ANNOUNCEMENT_TITLE_MAX = 120;
+const EMAIL_ANNOUNCEMENT_DESC_MAX = 2000;
 
 const ADMIN_TAB_TO_ROUTE = {
     dashboard: 'dashboard',
@@ -166,6 +170,8 @@ const AdminPanel = () => {
     const [announcementsPage, setAnnouncementsPage] = useState(1);
     const [announcementsPagination, setAnnouncementsPagination] = useState(null);
     const [showAnnouncementModal, setShowAnnouncementModal] = useState(false);
+    /** 'website' | 'email' — create mode; edit keeps the original channel */
+    const [announcementModalKind, setAnnouncementModalKind] = useState('website');
     const [editingAnnouncement, setEditingAnnouncement] = useState(null);
     const [announcementForm, setAnnouncementForm] = useState({
         title: '', description: '', department: '', announcement_date: '', priority: false, send_email: false
@@ -473,32 +479,48 @@ const AdminPanel = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [location.pathname, hasAccess]);
 
-    const openAnnouncementModal = (announcement = null) => {
+    const openAnnouncementModal = (announcement = null, kind = 'website') => {
         if (announcement) {
+            const isEmail = !!announcement.send_email;
+            const titleMax = isEmail ? EMAIL_ANNOUNCEMENT_TITLE_MAX : WEBSITE_ANNOUNCEMENT_TITLE_MAX;
+            const descMax = isEmail ? EMAIL_ANNOUNCEMENT_DESC_MAX : WEBSITE_ANNOUNCEMENT_DESC_MAX;
+            setAnnouncementModalKind(isEmail ? 'email' : 'website');
             setEditingAnnouncement(announcement);
             setAnnouncementForm({
-                title: (announcement.title || '').slice(0, ANNOUNCEMENT_TITLE_MAX),
-                description: (announcement.description || '').slice(0, ANNOUNCEMENT_DESC_MAX),
+                title: (announcement.title || '').slice(0, titleMax),
+                description: (announcement.description || '').slice(0, descMax),
                 department: announcement.department || '',
                 announcement_date: announcement.announcement_date ? announcement.announcement_date.split('T')[0] : '',
                 priority: !!announcement.priority,
-                send_email: !!announcement.send_email
+                send_email: isEmail
             });
         } else {
+            const isEmail = kind === 'email';
+            setAnnouncementModalKind(isEmail ? 'email' : 'website');
             setEditingAnnouncement(null);
             setAnnouncementForm({
                 title: '', description: '', department: '',
                 announcement_date: new Date().toISOString().split('T')[0],
                 priority: false,
-                send_email: false
+                send_email: isEmail
             });
         }
         setShowAnnouncementModal(true);
     };
 
+    const announcementTitleMax = announcementModalKind === 'email'
+        ? EMAIL_ANNOUNCEMENT_TITLE_MAX
+        : WEBSITE_ANNOUNCEMENT_TITLE_MAX;
+    const announcementDescMax = announcementModalKind === 'email'
+        ? EMAIL_ANNOUNCEMENT_DESC_MAX
+        : WEBSITE_ANNOUNCEMENT_DESC_MAX;
+
     const saveAnnouncement = async () => {
         try {
-            const payload = { ...announcementForm };
+            const payload = {
+                ...announcementForm,
+                send_email: announcementModalKind === 'email'
+            };
             if (!editingAnnouncement && typeof selectedSeasonId === 'number') {
                 payload.season_id = selectedSeasonId;
             }
@@ -511,8 +533,8 @@ const AdminPanel = () => {
                 setAlert({
                     type: 'success',
                     message: payload.send_email
-                        ? 'Announcement created and emailed to members!'
-                        : 'Announcement created (website only)!'
+                        ? 'Email announcement sent to members!'
+                        : 'Website announcement posted!'
                 });
             }
             setShowAnnouncementModal(false);
@@ -1062,9 +1084,22 @@ const AdminPanel = () => {
                                     <h2 className="AdminPanel__sectionTitle">
                                         <MdCampaign /> Announcements
                                     </h2>
-                                    <button className="AdminPanel__addBtn" onClick={() => openAnnouncementModal()}>
-                                        <MdAdd /> Add Announcement
-                                    </button>
+                                    <div className="AdminPanel__headerActions">
+                                        <button
+                                            type="button"
+                                            className="AdminPanel__addBtn AdminPanel__addBtn--secondary"
+                                            onClick={() => openAnnouncementModal(null, 'website')}
+                                        >
+                                            <MdAdd /> Website post
+                                        </button>
+                                        <button
+                                            type="button"
+                                            className="AdminPanel__addBtn"
+                                            onClick={() => openAnnouncementModal(null, 'email')}
+                                        >
+                                            <MdEmail /> Email broadcast
+                                        </button>
+                                    </div>
                                 </div>
 
                                 {announcementsLoading && announcements.length === 0 ? (
@@ -1129,44 +1164,52 @@ const AdminPanel = () => {
                                         role="presentation"
                                     >
                                         <div
-                                            className="AdminPanel__modalContent"
+                                            className={`AdminPanel__modalContent${announcementModalKind === 'email' ? ' AdminPanel__modalContent--large' : ''}`}
                                             onClick={e => e.stopPropagation()}
                                             role="dialog"
                                             aria-modal="true"
                                         >
-                                            <h3 className="AdminPanel__modalTitle">{editingAnnouncement ? 'Edit Announcement' : 'Add Announcement'}</h3>
-                                            {!editingAnnouncement && (
-                                                <p className="AdminPanel__emailNote" role="note">
-                                                    {announcementForm.send_email
-                                                        ? 'This announcement will appear on the website and an email will be sent to all members.'
-                                                        : 'This announcement will appear on the website only. Check “Send email” to also notify members by mail.'}
-                                                </p>
-                                            )}
+                                            <h3 className="AdminPanel__modalTitle">
+                                                {editingAnnouncement
+                                                    ? (announcementModalKind === 'email' ? 'Edit email announcement' : 'Edit website announcement')
+                                                    : (announcementModalKind === 'email' ? 'Email broadcast' : 'Website announcement')}
+                                            </h3>
+                                            <p className="AdminPanel__emailNote" role="note">
+                                                {announcementModalKind === 'email'
+                                                    ? (editingAnnouncement
+                                                        ? 'Editing an emailed announcement. Saving does not resend the email.'
+                                                        : 'Longer copy for email. This will be sent to all members and also appear on the website.')
+                                                    : (editingAnnouncement
+                                                        ? 'Editing a short website feed post.'
+                                                        : 'Short copy for the website feed only — no email will be sent.')}
+                                            </p>
                                             <div className="AdminPanel__formGroup">
                                                 <label htmlFor="announcement-title">Title *</label>
                                                 <input
                                                     id="announcement-title"
                                                     value={announcementForm.title}
-                                                    onChange={e => setAnnouncementForm({ ...announcementForm, title: e.target.value.slice(0, ANNOUNCEMENT_TITLE_MAX) })}
-                                                    placeholder="Title"
-                                                    maxLength={ANNOUNCEMENT_TITLE_MAX}
+                                                    onChange={e => setAnnouncementForm({ ...announcementForm, title: e.target.value.slice(0, announcementTitleMax) })}
+                                                    placeholder={announcementModalKind === 'email' ? 'Email subject / title' : 'Short title'}
+                                                    maxLength={announcementTitleMax}
                                                 />
-                                                <span className={`AdminPanel__charCount${announcementForm.title.length >= ANNOUNCEMENT_TITLE_MAX ? ' is-max' : ''}`}>
-                                                    {announcementForm.title.length}/{ANNOUNCEMENT_TITLE_MAX}
+                                                <span className={`AdminPanel__charCount${announcementForm.title.length >= announcementTitleMax ? ' is-max' : ''}`}>
+                                                    {announcementForm.title.length}/{announcementTitleMax}
                                                 </span>
                                             </div>
                                             <div className="AdminPanel__formGroup">
-                                                <label htmlFor="announcement-description">Description *</label>
+                                                <label htmlFor="announcement-description">
+                                                    {announcementModalKind === 'email' ? 'Email body *' : 'Description *'}
+                                                </label>
                                                 <textarea
                                                     id="announcement-description"
                                                     value={announcementForm.description}
-                                                    onChange={e => setAnnouncementForm({ ...announcementForm, description: e.target.value.slice(0, ANNOUNCEMENT_DESC_MAX) })}
-                                                    placeholder="Description"
-                                                    rows={4}
-                                                    maxLength={ANNOUNCEMENT_DESC_MAX}
+                                                    onChange={e => setAnnouncementForm({ ...announcementForm, description: e.target.value.slice(0, announcementDescMax) })}
+                                                    placeholder={announcementModalKind === 'email' ? 'Full email message…' : 'Brief description for the feed'}
+                                                    rows={announcementModalKind === 'email' ? 10 : 4}
+                                                    maxLength={announcementDescMax}
                                                 />
-                                                <span className={`AdminPanel__charCount${announcementForm.description.length >= ANNOUNCEMENT_DESC_MAX ? ' is-max' : ''}`}>
-                                                    {announcementForm.description.length}/{ANNOUNCEMENT_DESC_MAX}
+                                                <span className={`AdminPanel__charCount${announcementForm.description.length >= announcementDescMax ? ' is-max' : ''}`}>
+                                                    {announcementForm.description.length}/{announcementDescMax}
                                                 </span>
                                             </div>
                                             <div className="AdminPanel__formGroup">
@@ -1183,22 +1226,13 @@ const AdminPanel = () => {
                                                     {' '}Priority
                                                 </label>
                                             </div>
-                                            {!editingAnnouncement && (
-                                                <div className="AdminPanel__formGroup">
-                                                    <label htmlFor="announcement-send-email">
-                                                        <input
-                                                            id="announcement-send-email"
-                                                            type="checkbox"
-                                                            checked={announcementForm.send_email}
-                                                            onChange={e => setAnnouncementForm({ ...announcementForm, send_email: e.target.checked })}
-                                                        />
-                                                        {' '}Send email notification to all members
-                                                    </label>
-                                                </div>
-                                            )}
                                             <div className="AdminPanel__modalActions">
                                                 <button className="AdminPanel__modalBtn AdminPanel__modalBtn--secondary" onClick={() => setShowAnnouncementModal(false)}>Cancel</button>
-                                                <button className="AdminPanel__modalBtn AdminPanel__modalBtn--primary" onClick={saveAnnouncement}>{editingAnnouncement ? 'Save' : 'Create'}</button>
+                                                <button className="AdminPanel__modalBtn AdminPanel__modalBtn--primary" onClick={saveAnnouncement}>
+                                                    {editingAnnouncement
+                                                        ? 'Save'
+                                                        : (announcementModalKind === 'email' ? 'Send email' : 'Post to website')}
+                                                </button>
                                             </div>
                                         </div>
                                     </div>,

--- a/client/src/pages/Home/FeedSection/FeedSection.css
+++ b/client/src/pages/Home/FeedSection/FeedSection.css
@@ -104,6 +104,13 @@
 }
 
 /* Create Button */
+.Feed__createActions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
 .Feed__createBtn {
     display: inline-flex;
     align-items: center;
@@ -135,6 +142,19 @@
     font-size: 1rem;
 }
 
+.Feed__createBtn--secondary {
+    background: transparent;
+    border: 1px solid rgba(142, 194, 240, 0.4);
+    color: #8EC2F0;
+    box-shadow: none;
+}
+
+.Feed__createBtn--secondary:hover {
+    background: rgba(3, 169, 244, 0.12);
+    border-color: rgba(3, 169, 244, 0.5);
+    box-shadow: none;
+}
+
 /* Modal */
 .Feed__modalOverlay {
     position: fixed;
@@ -156,7 +176,7 @@
     border-radius: 20px;
     padding: 32px;
     width: 100%;
-    max-width: 600px;
+    max-width: 520px;
     max-height: 90vh;
     overflow-y: auto;
     margin: auto;
@@ -164,6 +184,10 @@
     backdrop-filter: blur(14px) saturate(160%);
     box-shadow: 0 8px 32px rgba(0, 0, 0, .3);
     position: relative;
+}
+
+.Feed__modalContent--large {
+    max-width: 720px;
 }
 
 .Feed__modalClose {
@@ -271,7 +295,7 @@
 }
 
 .Feed__formHint {
-    margin: 0;
+    margin: 0 0 18px;
     padding: 10px 14px;
     background: rgba(3, 169, 244, 0.12);
     border: 1px solid rgba(3, 169, 244, 0.28);
@@ -279,6 +303,18 @@
     color: #8EC2F0;
     font-size: 0.85rem;
     line-height: 1.45;
+}
+
+.Feed__charCount {
+    display: block;
+    margin-top: 6px;
+    font-size: 0.75rem;
+    color: #5AA0E6;
+    text-align: right;
+}
+
+.Feed__charCount.is-max {
+    color: #ffb4b4;
 }
 
 .Feed__formError {
@@ -364,6 +400,11 @@
     .Feed__createBtn {
         width: 100%;
         justify-content: center;
+    }
+
+    .Feed__createActions {
+        width: 100%;
+        flex-direction: column;
     }
 
     .Feed__modalContent {

--- a/client/src/pages/Home/FeedSection/FeedSection.jsx
+++ b/client/src/pages/Home/FeedSection/FeedSection.jsx
@@ -6,7 +6,21 @@ import ApiService from '../../../services/api';
 import Pagination from '../../../components/Pagination';
 import SeasonBadge from '../../../components/SeasonBadge';
 import { useSeason } from '../../../context/SeasonContext';
-import { FiPlus, FiX } from 'react-icons/fi';
+import { FiPlus, FiMail, FiX } from 'react-icons/fi';
+
+const WEBSITE_TITLE_MAX = 50;
+const WEBSITE_DESC_MAX = 220;
+const EMAIL_TITLE_MAX = 120;
+const EMAIL_DESC_MAX = 2000;
+
+const emptyForm = (sendEmail = false) => ({
+  title: '',
+  description: '',
+  department: '',
+  announcement_date: '',
+  priority: false,
+  send_email: sendEmail
+});
 
 const FeedSection = memo(() => {
   const { seasonFilters, isAll, selectedSeasonId } = useSeason();
@@ -16,27 +30,23 @@ const FeedSection = memo(() => {
   const [page, setPage] = useState(1);
   const [pagination, setPagination] = useState(null);
   const [userRole, setUserRole] = useState(null);
-  const [showModal, setShowModal] = useState(false);
-  const [formData, setFormData] = useState({
-    title: '',
-    description: '',
-    department: '',
-    announcement_date: '',
-    priority: false,
-    send_email: false
-  });
+  const [modalKind, setModalKind] = useState(null); // 'website' | 'email' | null
+  const [formData, setFormData] = useState(emptyForm(false));
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState(null);
 
-  // Check user role
+  const isEmailModal = modalKind === 'email';
+  const titleMax = isEmailModal ? EMAIL_TITLE_MAX : WEBSITE_TITLE_MAX;
+  const descMax = isEmailModal ? EMAIL_DESC_MAX : WEBSITE_DESC_MAX;
+
   useEffect(() => {
     const checkUserRole = async () => {
       if (ApiService.isAuthenticated()) {
         try {
           const user = await ApiService.getProfile();
           setUserRole(user.role);
-        } catch (error) {
-          console.error('Error fetching user role:', error);
+        } catch (err) {
+          console.error('Error fetching user role:', err);
           setUserRole(null);
         }
       } else {
@@ -56,8 +66,7 @@ const FeedSection = memo(() => {
         ...seasonFilters,
       });
       const list = Array.isArray(result) ? result : (result.data || []);
-      
-      // Map API response to component format
+
       const mappedAnnouncements = list.map(announcement => ({
         id: announcement.announcement_id,
         title: announcement.title,
@@ -68,12 +77,11 @@ const FeedSection = memo(() => {
         season: announcement.season || null,
         season_id: announcement.season_id ?? null,
       }));
-      
+
       setAnnouncements(mappedAnnouncements);
       setPagination(Array.isArray(result) ? null : (result.pagination || null));
     } catch (err) {
       console.error('Error fetching announcements:', err);
-      // If it's a JSON parse error, the API endpoint might not be available
       if (err.message && err.message.includes('JSON')) {
         setError('Announcements API is not available. Please ensure the backend server is running.');
       } else {
@@ -94,8 +102,22 @@ const FeedSection = memo(() => {
   const isBoardOrAdmin = userRole === 'board' || userRole === 'admin';
   const canCreateAnnouncements = isBoardOrAdmin;
 
+  const openModal = (kind) => {
+    setModalKind(kind);
+    setFormData(emptyForm(kind === 'email'));
+    setSubmitError(null);
+  };
+
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
+    if (name === 'title') {
+      setFormData(prev => ({ ...prev, title: value.slice(0, titleMax) }));
+      return;
+    }
+    if (name === 'description') {
+      setFormData(prev => ({ ...prev, description: value.slice(0, descMax) }));
+      return;
+    }
     setFormData(prev => ({
       ...prev,
       [name]: type === 'checkbox' ? checked : value
@@ -108,21 +130,15 @@ const FeedSection = memo(() => {
     setSubmitError(null);
 
     try {
-      const payload = { ...formData };
+      const payload = {
+        ...formData,
+        send_email: modalKind === 'email'
+      };
       if (typeof selectedSeasonId === 'number') {
         payload.season_id = selectedSeasonId;
       }
       await ApiService.createAnnouncement(payload);
-      setShowModal(false);
-      setFormData({
-        title: '',
-        description: '',
-        department: '',
-        announcement_date: '',
-        priority: false,
-        send_email: false
-      });
-      // Refresh announcements list
+      handleCloseModal();
       setPage(1);
       await fetchAnnouncements(1);
     } catch (err) {
@@ -134,15 +150,8 @@ const FeedSection = memo(() => {
   };
 
   const handleCloseModal = () => {
-    setShowModal(false);
-    setFormData({
-      title: '',
-      description: '',
-      department: '',
-      announcement_date: '',
-      priority: false,
-      send_email: false
-    });
+    setModalKind(null);
+    setFormData(emptyForm(false));
     setSubmitError(null);
   };
 
@@ -151,15 +160,28 @@ const FeedSection = memo(() => {
       <div className="Feed__head">
         <h2 id="feed-heading" className="Feed__title">Announcements & Updates</h2>
         {canCreateAnnouncements && (
-          <motion.button
-            className="Feed__createBtn"
-            onClick={() => setShowModal(true)}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            <FiPlus />
-            Create Announcement
-          </motion.button>
+          <div className="Feed__createActions">
+            <motion.button
+              type="button"
+              className="Feed__createBtn Feed__createBtn--secondary"
+              onClick={() => openModal('website')}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              <FiPlus />
+              Website post
+            </motion.button>
+            <motion.button
+              type="button"
+              className="Feed__createBtn"
+              onClick={() => openModal('email')}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              <FiMail />
+              Email broadcast
+            </motion.button>
+          </div>
         )}
       </div>
       <div className="Feed__grid">
@@ -195,18 +217,18 @@ const FeedSection = memo(() => {
                 <> {' '}<SeasonBadge season={a.season} /></>
               )}
             </h3>
-            <p className="FeedCard__desc">{a.desc}</p>
-            {/* <motion.a href="/announcements" className="FeedCard__more" whileHover={{ color: '#fff', x: 3 }}>Read more →</motion.a> */}
+            <p className="FeedCard__desc">
+              {a.desc && a.desc.length > 280 ? `${a.desc.slice(0, 279)}…` : a.desc}
+            </p>
           </motion.article>
           ))
         )}
       </div>
       <Pagination pagination={pagination} onPageChange={setPage} />
 
-      {/* Create Announcement Modal — portaled so parent transforms cannot pin it off-screen */}
       {createPortal(
         <AnimatePresence>
-          {showModal && (
+          {modalKind && (
             <motion.div
               className="Feed__modalOverlay"
               initial={{ opacity: 0 }}
@@ -215,7 +237,7 @@ const FeedSection = memo(() => {
               onClick={handleCloseModal}
             >
               <motion.div
-                className="Feed__modalContent"
+                className={`Feed__modalContent${isEmailModal ? ' Feed__modalContent--large' : ''}`}
                 initial={{ opacity: 0, scale: 0.9, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.9, y: 20 }}
@@ -229,7 +251,14 @@ const FeedSection = memo(() => {
                   <FiX />
                 </button>
 
-                <h3 className="Feed__modalTitle">Create New Announcement</h3>
+                <h3 className="Feed__modalTitle">
+                  {isEmailModal ? 'Email broadcast' : 'Website announcement'}
+                </h3>
+                <p className="Feed__formHint" role="note">
+                  {isEmailModal
+                    ? 'Longer copy for email. Sent to all members and shown on the website.'
+                    : 'Short copy for the website feed only — no email will be sent.'}
+                </p>
 
                 <form onSubmit={handleSubmit} className="Feed__form">
                   <div className="Feed__formGroup">
@@ -241,21 +270,29 @@ const FeedSection = memo(() => {
                       value={formData.title}
                       onChange={handleInputChange}
                       required
-                      placeholder="Enter announcement title"
+                      maxLength={titleMax}
+                      placeholder={isEmailModal ? 'Email subject / title' : 'Short title'}
                     />
+                    <span className={`Feed__charCount${formData.title.length >= titleMax ? ' is-max' : ''}`}>
+                      {formData.title.length}/{titleMax}
+                    </span>
                   </div>
 
                   <div className="Feed__formGroup">
-                    <label htmlFor="description">Description *</label>
+                    <label htmlFor="description">{isEmailModal ? 'Email body *' : 'Description *'}</label>
                     <textarea
                       id="description"
                       name="description"
                       value={formData.description}
                       onChange={handleInputChange}
                       required
-                      rows="4"
-                      placeholder="Enter announcement description"
+                      rows={isEmailModal ? 10 : 4}
+                      maxLength={descMax}
+                      placeholder={isEmailModal ? 'Full email message…' : 'Brief description for the feed'}
                     />
+                    <span className={`Feed__charCount${formData.description.length >= descMax ? ' is-max' : ''}`}>
+                      {formData.description.length}/{descMax}
+                    </span>
                   </div>
 
                   <div className="Feed__formGroup">
@@ -295,24 +332,6 @@ const FeedSection = memo(() => {
                     </label>
                   </div>
 
-                  <div className="Feed__formGroup Feed__formGroup--checkbox">
-                    <label>
-                      <input
-                        type="checkbox"
-                        name="send_email"
-                        checked={formData.send_email}
-                        onChange={handleInputChange}
-                      />
-                      <span>Send email notification to all members</span>
-                    </label>
-                  </div>
-
-                  {formData.send_email && (
-                    <p className="Feed__formHint" role="note">
-                      An email about this announcement will be sent to all members.
-                    </p>
-                  )}
-
                   {submitError && (
                     <div className="Feed__formError">{submitError}</div>
                   )}
@@ -331,7 +350,9 @@ const FeedSection = memo(() => {
                       className="Feed__formBtn Feed__formBtn--submit"
                       disabled={submitting}
                     >
-                      {submitting ? 'Creating...' : 'Create Announcement'}
+                      {submitting
+                        ? (isEmailModal ? 'Sending...' : 'Posting...')
+                        : (isEmailModal ? 'Send email' : 'Post to website')}
                     </button>
                   </div>
                 </form>

--- a/server/controllers/announcements.js
+++ b/server/controllers/announcements.js
@@ -159,6 +159,21 @@ const addAnnouncement = async (req, res) => {
 
     const shouldSendEmail = send_email === true || send_email === 'true' || send_email === 1;
 
+    const titleMax = shouldSendEmail ? 120 : 50;
+    const descMax = shouldSendEmail ? 2000 : 220;
+    if (String(title).trim().length > titleMax) {
+      return res.status(400).json({
+        success: false,
+        error: `Title must be at most ${titleMax} characters for ${shouldSendEmail ? 'email' : 'website'} announcements`
+      });
+    }
+    if (String(description).trim().length > descMax) {
+      return res.status(400).json({
+        success: false,
+        error: `Description must be at most ${descMax} characters for ${shouldSendEmail ? 'email' : 'website'} announcements`
+      });
+    }
+
     const announcement = await Announcement.create({
       title,
       description,
@@ -240,6 +255,21 @@ const updateAnnouncement = async (req, res) => {
     }
     if (is_active !== undefined) {
       announcement.is_active = is_active === true || is_active === 'true' || is_active === 1;
+    }
+
+    const titleMax = announcement.send_email ? 120 : 50;
+    const descMax = announcement.send_email ? 2000 : 220;
+    if (String(announcement.title || '').trim().length > titleMax) {
+      return res.status(400).json({
+        success: false,
+        error: `Title must be at most ${titleMax} characters for this announcement type`
+      });
+    }
+    if (String(announcement.description || '').trim().length > descMax) {
+      return res.status(400).json({
+        success: false,
+        error: `Description must be at most ${descMax} characters for this announcement type`
+      });
     }
 
     await announcement.save();


### PR DESCRIPTION
- Updated the AdminPanel to support separate announcement types for website posts and email broadcasts.
- Introduced new constants for title and description character limits based on the announcement type.
- Modified the announcement modal to allow users to specify the type when creating or editing announcements.
- Enhanced the save functionality to correctly handle the 'send_email' flag based on the selected announcement type.
- Improved UI elements for adding announcements, providing clear options for users.